### PR TITLE
PowerShell scripts for uninstalling

### DIFF
--- a/windows/registerUninstall.ps1
+++ b/windows/registerUninstall.ps1
@@ -1,0 +1,14 @@
+﻿$installationDirectory = $args[0]
+
+$ErrorActionPreference = 'Continue'
+
+New-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name DisplayName -PropertyType String -Value "Luna Studio"
+$uninstallScriptPath = "$($installationDirectory)\LunaStudio\uninstallLunaStudio.ps1"
+$uninstallString     = "$env:SYSTEMROOT\System32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -file `"$uninstallScriptPath`""
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name UninstallString -PropertyType String -Value $uninstallString
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name DisplayIcon -PropertyType String -Value "$installationDirectory\LunaStudio\current\bin\public\luna-studio\luna-studio.exe"
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name NoModify -PropertyType DWord -Value 1
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name NoRepair -PropertyType DWord -Value 1
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name EstimatedSize -PropertyType DWord -Value 1048576
+New-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio -Name Publisher -PropertyType String -Value "New Byte Order"

--- a/windows/uninstallLunaStudio.ps1
+++ b/windows/uninstallLunaStudio.ps1
@@ -1,0 +1,32 @@
+﻿ $ErrorActionPreference = 'Continue'
+
+ if(!$PSScriptRoot) {
+     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+ }
+
+ Write-Host "Uninstalling Luna services"
+ Push-Location -Path "$($PSScriptRoot)\current\config\windows"
+ & '.\uninstallAll.bat'
+ Pop-Location
+
+ Write-Host "Removing $env:APPDATA\LunaStudio*"
+ Get-ChildItem -path "$env:APPDATA" -Filter "LunaStudio*" | Remove-Item -Force -Recurse
+
+ $uncLunaStudio = "\\?\" + $PSScriptRoot
+ Write-Host "Removing symlink $PSScriptRoot\current"
+ $currentPath = Join-Path $PSScriptRoot -Child "current"
+ [System.IO.Directory]::Delete($currentPath, $true)
+
+ Write-Host "Removing $PSScriptRoot"
+ Remove-Item -Force -Recurse $uncLunaStudio
+
+ Write-Host "Removing $env:USERPROFILE\LunaStudio*"
+ Remove-Item -Force -Recurse "$env:USERPROFILE\.luna"
+
+ Write-Host "Removing Start Menu shortcut"
+ Remove-Item -Force "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\LunaStudio.lnk"
+
+ Write-Host "Removing entries in Windows Registry"
+ Remove-Item -Recurse -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\LunaStudio
+
+ Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
registerUninstall adds relevant info to Windows registry so that Luna Studio appears in Add/Remove Programs.
uninstallLunaStudio deletes everything that we created