### PR TITLE
Supervisor fixes

### DIFF
--- a/supervisor/supervisord-package.conf
+++ b/supervisor/supervisord-package.conf
@@ -1,9 +1,6 @@
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)
 
-[inet_http_server]          ; inet (TCP) server disabled by default
-port=127.0.0.1:9101         ; (ip_address:port specifier, *:port for all iface)
-
 [supervisord]
 logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/supervisord.log  ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
@@ -14,7 +11,7 @@ nodaemon=false               ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
 childlogdir=%(ENV_LUNA_STUDIO_LOG_PATH)s ; ('AUTO' child log dir, default $TEMP)
-environment=LUNAROOT="%(ENV_LUNA_STUDIO_CONFIG_PATH)s/env"
+environment=LUNAROOT="%(ENV_LUNA_STUDIO_CONFIG_PATH)s/env",LD_LIBRARY_PATH="%(ENV_OLD_LIBPATH)s"
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
@@ -23,7 +20,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:luna-atom]
-environment=ATOM_HOME=%(ENV_LUNA_STUDIO_GUI_CONFIG_PATH)s,LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
+environment=ATOM_HOME="%(ENV_LUNA_STUDIO_GUI_CONFIG_PATH)s"
 command=%(ENV_LUNA_STUDIO_GUI_PATH)s -w %(ENV_LUNA_STUDIO_ATOM_ARG)s
 priority=2
 process_name=luna-atom
@@ -39,25 +36,21 @@ stderr_logfile_maxbytes=0
 
 [eventlistener:luna-atom_exit]
 command=%(ENV_LUNA_STUDIO_KILL_PATH)s
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 process_name=luna-atom-kill
 events=PROCESS_STATE_EXITED
 
 [program:ws-connector]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/ws-connector -v5
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 directory=%(ENV_PWD)s/
 redirect_stderr=true
 
 [program:broker]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/broker -v5
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 directory=%(ENV_PWD)s/
 redirect_stderr=true
 
 [program:luna-empire]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-empire -v5
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 directory=%(ENV_PWD)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/luna-empire.log
@@ -72,13 +65,11 @@ redirect_stderr=true
 
 [program:logger]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-empire-logger -v4
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 directory=%(ENV_PWD)s/
 redirect_stderr=true
 
 [program:undo-redo]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/undo-redo -v5
-environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
 directory=%(ENV_PWD)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/undo-redo.log


### PR DESCRIPTION
This should fix luna/luna-manager#112, cause I suspect the cause is an unescaped space in ATOM_HOME. Maybe it will resolve #701, because supervisord no longer start its HTTP server on port 9101