### PR TITLE
Use new extensible snapshots

### DIFF
--- a/build-config/backend/nbo.yaml
+++ b/build-config/backend/nbo.yaml
@@ -1,0 +1,77 @@
+resolver: lts-9.21
+name: nbo
+packages:
+- cond-0.4.1.1
+- containers-0.5.8.2
+- error-util-0.0.1.1
+- fingertree-0.1.1.0
+- ghc-mtl-1.2.1.0
+- ghc-session-0.1.2.0
+- path-0.6.1
+- shelly-1.6.8.4
+- serialport-0.4.7
+- git: git@github.com:luna/luna.git
+  commit: 47ca5bca98f45fc96124b789d122fb3553e6056f
+  subdirs:
+  - core
+  - passes
+  - syntax/text/parser
+  - syntax/text/lexer
+  - stdlib
+  - project
+- git: git@github.com:luna/container.git
+  commit: 61ff909efd466735cd4820f9ab2c564e324b5546
+- git: git@github.com:luna/convert.git
+  commit: 6b1a30ae3ead794e3839d6552fd48a56b4447d24
+- git: git@github.com:luna/data-base.git
+  commit: a81f2eb37b0bddbc3391c8a29860b921aa94f3c8
+- git: git@github.com:luna/data-construction.git
+  commit: a6afda3b96efe00938aba61ac12a2f5f2134ff3d
+- git: git@github.com:luna/data-layer.git
+  commit: 8a5773adba33d71a311ba0b4123b744213b0be91
+- git: git@github.com:luna/data-pool.git
+  commit: 4cc75aeb82ad2885427211a1be9cb0c7d9582c01
+- git: git@github.com:luna/data-prop.git
+  commit: b5f02ced2912501d923c07950789fbcf44a6a9ce
+- git: git@github.com:luna/data-repr.git
+  commit: 9da4c9b2534693cfe82adeb37f12eaadacb41e62
+- git: git@github.com:luna/data-result.git
+  commit: 89b0bb545ddde953c5692f234163748b9b4e84d2
+- git: git@github.com:luna/data-rtuple.git
+  commit: 4f5153aed4944317942ff9025c79f7fc3be85181
+- git: git@github.com:luna/data-shell.git
+  commit: f58214001b64d35f7502ec76bdc5410ba97032ff
+- git: git@github.com:luna/dependent-state.git
+  commit: 8c3d63bb78c24fcfadd22efe1a0b8071c4240ff6
+- git: git@github.com:luna/functor-utils.git
+  commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223
+- git: git@github.com:luna/fuzzy-text.git
+  commit: 758f81a9914f46efa9137562b0a5ca3df9ce0661
+- git: git@github.com:luna/impossible.git
+  commit: a1606cccc12cb521acbc598e52c481b9054b42a7
+- git: git@github.com:luna/layouting
+  commit: c75acefee30d1c853da7e651c358d72b60386a07
+- git: git@github.com:luna/lens-utils.git
+  commit: 3ba7d5da78aab023fc74c44fc7445ffab0bc18e0
+- git: git@github.com:luna/monad-branch
+  commit: 7c7a6d657e7db8c3dcd80fbed0a7e02e02f43ae3
+- git: git@github.com:luna/monoid
+  commit: e63e373d67cd8dd7c179a618f5d32f6ffb3abdd3
+- git: git@github.com:luna/parsert
+  commit: cbcd88c87e8888ebfeacd258cca96b3d6d489d35
+- git: git@github.com:luna/poly-control.git
+  commit: 965e23539a001517994398ae02421334bf77c6e6
+- git: git@github.com:luna/prologue.git
+  commit: e930d2854258a4160cf1b10dece72448e500c35e
+- git: git@github.com:luna/terminal-text
+  commit: a7f6158465aaa9998fcb094d74906f608ce385c5
+- git: git@github.com:luna/text-processing
+  commit: fe9834f3f5583086d76b12779a1c2a5290c72b0d
+- git: git@github.com:luna/type-cache.git
+  commit: f4292663aea639c17f66ba3d67e09c79ebf62982
+- git: git@github.com:luna/typelevel.git
+  commit: 107db9368e95e192d70c0dec274ecfe3592101d2
+- git: git@github.com:luna/vector-text
+  commit: be6907da96975af1c5ca09555797a9891689cdb3
+- git: git@github.com:luna/visualization-api.git
+  commit: ddfcd1e0372b93e947b380b911c123fe67227b21

--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -1,94 +1,24 @@
-resolver: lts-8.2
+resolver: nbo.yaml
 ghc-options:
-  '*': -threaded -fconstraint-solver-iterations=100 -O2
+  $locals: -threaded -O0
+  $everything: -fconstraint-solver-iterations=100
+  matrix: -O0
 local-bin-path:
   ../../dist/bin/private
 
-extra-deps:
-- aeson-1.1.1.0
-- ansi-terminal-0.6.3.1
-- cond-0.4.1.1
-- containers-0.5.8.2
-- error-util-0.0.1.1
-- ghc-mtl-1.2.1.0
-- ghc-session-0.1.2.0
-- path-0.6.1
-- shelly-1.6.8.4
-- serialport-0.4.7
-- uuid-1.3.13
-
 packages:
-- {extra-dep: false, location: ../../libs/luna-empire}
-- {extra-dep: true, location: ../../libs/batch/plugins/luna-empire}
-- {extra-dep: true, location: ../../libs/batch/plugins/request-monitor}
-- {extra-dep: true, location: ../../libs/luna-studio-common}
-- {extra-dep: true, location: ../../libs/m-logger}
-- {extra-dep: true, location: ../../libs/ws-connector}
-- {extra-dep: true, location: ../../libs/zmq-bus-config}
-- {extra-dep: true, location: ../../libs/zmq-bus}
-- {extra-dep: true, location: ../../libs/zmq-rpc}
-- {location: ../../tools/batch/plugins/ws-connector}
-- {location: ../../tools/batch/plugins/broker}
-- {location: ../../libs/undo-redo}
-- {location: ../../tools/batch/plugins/bus-logger}
-- {location: ../../tools/batch/plugins/luna-empire}
-- {location: ../../tools/batch/plugins/request-monitor}
-- extra-dep: true
-  location: {commit: 47ca5bca98f45fc96124b789d122fb3553e6056f, git: 'git@github.com:luna/luna.git'}
-  subdirs: [core, passes, syntax/text/parser, syntax/text/lexer, stdlib, project]
-- extra-dep: true
-  location: {commit: 61ff909efd466735cd4820f9ab2c564e324b5546, git: 'git@github.com:luna/container.git'}
-- extra-dep: true
-  location: {commit: 4cc75aeb82ad2885427211a1be9cb0c7d9582c01, git: 'git@github.com:luna/data-pool.git'}
-- extra-dep: true
-  location: {commit: 6b1a30ae3ead794e3839d6552fd48a56b4447d24, git: 'git@github.com:luna/convert.git'}
-- extra-dep: true
-  location: {commit: a81f2eb37b0bddbc3391c8a29860b921aa94f3c8, git: 'git@github.com:luna/data-base.git'}
-- extra-dep: true
-  location: {commit: a6afda3b96efe00938aba61ac12a2f5f2134ff3d, git: 'git@github.com:luna/data-construction.git'}
-- extra-dep: true
-  location: {commit: 8a5773adba33d71a311ba0b4123b744213b0be91, git: 'git@github.com:luna/data-layer.git'}
-- extra-dep: true
-  location: {commit: 9da4c9b2534693cfe82adeb37f12eaadacb41e62, git: 'git@github.com:luna/data-repr.git'}
-- extra-dep: true
-  location: {commit: 89b0bb545ddde953c5692f234163748b9b4e84d2, git: 'git@github.com:luna/data-result.git'}
-- extra-dep: true
-  location: {commit: 8c3d63bb78c24fcfadd22efe1a0b8071c4240ff6, git: 'git@github.com:luna/dependent-state.git'}
-- extra-dep: true
-  location: {commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223, git: 'git@github.com:luna/functor-utils.git'}
-- extra-dep: true
-  location: {commit: 758f81a9914f46efa9137562b0a5ca3df9ce0661, git: 'git@github.com:luna/fuzzy-text.git'}
-- extra-dep: true
-  location: {commit: a1606cccc12cb521acbc598e52c481b9054b42a7, git: 'git@github.com:luna/impossible.git'}
-- extra-dep: true
-  location: {commit: 3ba7d5da78aab023fc74c44fc7445ffab0bc18e0, git: 'git@github.com:luna/lens-utils.git'}
-- extra-dep: true
-  location: {commit: 965e23539a001517994398ae02421334bf77c6e6, git: 'git@github.com:luna/poly-control.git'}
-- extra-dep: true
-  location: {commit: e930d2854258a4160cf1b10dece72448e500c35e, git: 'git@github.com:luna/prologue.git'}
-- extra-dep: true
-  location: {commit: f4292663aea639c17f66ba3d67e09c79ebf62982, git: 'git@github.com:luna/type-cache.git'}
-- extra-dep: true
-  location: {commit: 107db9368e95e192d70c0dec274ecfe3592101d2, git: 'git@github.com:luna/typelevel.git'}
-- extra-dep: true
-  location: {commit: b5f02ced2912501d923c07950789fbcf44a6a9ce, git: 'git@github.com:luna/data-prop.git'}
-- extra-dep: true
-  location: {commit: 4f5153aed4944317942ff9025c79f7fc3be85181, git: 'git@github.com:luna/data-rtuple.git'}
-- extra-dep: true
-  location: {commit: f58214001b64d35f7502ec76bdc5410ba97032ff, git: 'git@github.com:luna/data-shell.git'}
-- extra-dep: true
-  location: {commit: ddfcd1e0372b93e947b380b911c123fe67227b21, git: 'git@github.com:luna/visualization-api.git'}
-- extra-dep: true
-  location: {commit: e63e373d67cd8dd7c179a618f5d32f6ffb3abdd3, git: 'git@github.com:luna/monoid'}
-- extra-dep: true
-  location: {commit: fe9834f3f5583086d76b12779a1c2a5290c72b0d, git: 'git@github.com:luna/text-processing'}
-- extra-dep: true
-  location: {commit: cbcd88c87e8888ebfeacd258cca96b3d6d489d35, git: 'git@github.com:luna/parsert'}
-- extra-dep: true
-  location: {commit: be6907da96975af1c5ca09555797a9891689cdb3, git: 'git@github.com:luna/vector-text'}
-- extra-dep: true
-  location: {commit: a7f6158465aaa9998fcb094d74906f608ce385c5, git: 'git@github.com:luna/terminal-text'}
-- extra-dep: true
-  location: {commit: c75acefee30d1c853da7e651c358d72b60386a07, git: 'git@github.com:luna/layouting'}
-- extra-dep: true
-  location: {commit: 7c7a6d657e7db8c3dcd80fbed0a7e02e02f43ae3, git: 'git@github.com:luna/monad-branch'}
+- ../../libs/batch/plugins/luna-empire
+- ../../libs/batch/plugins/request-monitor
+- ../../libs/luna-empire
+- ../../libs/luna-studio-common
+- ../../libs/m-logger
+- ../../libs/undo-redo
+- ../../libs/ws-connector
+- ../../libs/zmq-bus
+- ../../libs/zmq-bus-config
+- ../../libs/zmq-rpc
+- ../../tools/batch/plugins/broker
+- ../../tools/batch/plugins/bus-logger
+- ../../tools/batch/plugins/luna-empire
+- ../../tools/batch/plugins/request-monitor
+- ../../tools/batch/plugins/ws-connector

--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -1,8 +1,8 @@
 resolver: nbo.yaml
 ghc-options:
-  $locals: -threaded -O0
-  $everything: -fconstraint-solver-iterations=100
-  matrix: -O0
+  $locals: -threaded -O2
+  $everything: -fconstraint-solver-iterations=100 -O2
+  matrix: -O0 # https://github.com/Daniel-Diaz/matrix/issues/43
 local-bin-path:
   ../../dist/bin/private
 

--- a/libs/luna-studio-common/package.yaml
+++ b/libs/luna-studio-common/package.yaml
@@ -58,14 +58,3 @@ default-extensions:
 library:
   source-dirs: src
   ghc-options: -Wall -O2 -threaded -DCOMPRESS_REQUESTS
-
-
-executables:
-  luna-studio-common-test:
-    source-dirs: test
-    main: Main.hs
-    ghc-options: -Wall -O2 -threaded
-    dependencies:
-      - base
-      - prologue
-      - luna-studio-common

--- a/libs/luna-studio-common/test/Main.hs
+++ b/libs/luna-studio-common/test/Main.hs
@@ -1,9 +1,0 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
-module Main where
-
-import           Prologue
-
-main :: IO ()
-main = return ()

--- a/luna-studio/nbo-front.yaml
+++ b/luna-studio/nbo-front.yaml
@@ -1,0 +1,56 @@
+resolver: lts-8.11
+name: nbo-front
+
+
+packages:
+- cond-0.4.1.1
+- datetime-0.3.1
+- ghcjs-dom-0.7.0.4
+- ghcjs-dom-jsffi-0.7.0.4
+- foundation-0.0.7
+- git: git@github.com:luna/container.git
+  commit: 61ff909efd466735cd4820f9ab2c564e324b5546
+- git: git@github.com:luna/convert.git
+  commit: b84f6fcc7b466760327b1d0f2e7150d9f78dfdc6
+- git: git@github.com:luna/data-construction.git
+  commit: a6afda3b96efe00938aba61ac12a2f5f2134ff3d
+- git: git@github.com:luna/data-layer.git
+  commit: 8a5773adba33d71a311ba0b4123b744213b0be91
+- git: git@github.com:luna/data-prop.git
+  commit: b5f02ced2912501d923c07950789fbcf44a6a9ce
+- git: git@github.com:luna/data-repr.git
+  commit: 9da4c9b2534693cfe82adeb37f12eaadacb41e62
+- git: git@github.com:luna/data-rtuple.git
+  commit: 4f5153aed4944317942ff9025c79f7fc3be85181
+- git: git@github.com:luna/dependent-state.git
+  commit: 8c3d63bb78c24fcfadd22efe1a0b8071c4240ff6
+- git: git@github.com:luna/functor-utils.git
+  commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223
+- git: git@github.com:luna/fuzzy-text.git
+  commit: 0b492788263c799b142f3f5e8c27f2ec800ea80c
+- git: git@github.com:luna/impossible.git
+  commit: a1606cccc12cb521acbc598e52c481b9054b42a7
+- git: git@github.com:luna/lens-utils.git
+  commit: 3ba7d5da78aab023fc74c44fc7445ffab0bc18e0
+- git: git@github.com:luna/luna.git
+  commit: 9c5d7adce748594b0ba1d86fa30ba6f140901c13
+  subdirs:
+  - syntax/text/lexer
+- git: git@github.com:luna/monoid
+  commit: e63e373d67cd8dd7c179a618f5d32f6ffb3abdd3
+- git: git@github.com:luna/monad-branch
+  commit: 7c7a6d657e7db8c3dcd80fbed0a7e02e02f43ae3
+- git: git@github.com:luna/parsert
+  commit: cbcd88c87e8888ebfeacd258cca96b3d6d489d35
+- git: git@github.com:luna/prologue.git
+  commit: c1c525d71b5e749f24e26f71d2d1a68019cae850
+- git: git@github.com:luna/react-flux
+  commit: ad94b1f2e4bc87b81853ff746b64c59b3eae7f09
+- git: git@github.com:luna/text-processing.git
+  commit: fe9834f3f5583086d76b12779a1c2a5290c72b0d
+- git: git@github.com:luna/typelevel.git
+  commit: 107db9368e95e192d70c0dec274ecfe3592101d2
+- git: git@github.com:luna/vector-text.git
+  commit: ed546316cdd896467276913a45073a0cb9e447b2
+- git: git@github.com:luna/visualization-api.git
+  commit: ddfcd1e0372b93e947b380b911c123fe67227b21

--- a/luna-studio/nbo-front.yaml
+++ b/luna-studio/nbo-front.yaml
@@ -27,13 +27,13 @@ packages:
 - git: git@github.com:luna/functor-utils.git
   commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223
 - git: git@github.com:luna/fuzzy-text.git
-  commit: 0b492788263c799b142f3f5e8c27f2ec800ea80c
+  commit: 758f81a9914f46efa9137562b0a5ca3df9ce0661
 - git: git@github.com:luna/impossible.git
   commit: a1606cccc12cb521acbc598e52c481b9054b42a7
 - git: git@github.com:luna/lens-utils.git
   commit: 3ba7d5da78aab023fc74c44fc7445ffab0bc18e0
 - git: git@github.com:luna/luna.git
-  commit: 9c5d7adce748594b0ba1d86fa30ba6f140901c13
+  commit: 47ca5bca98f45fc96124b789d122fb3553e6056f
   subdirs:
   - syntax/text/lexer
 - git: git@github.com:luna/monoid

--- a/luna-studio/stack.yaml
+++ b/luna-studio/stack.yaml
@@ -1,72 +1,19 @@
-resolver: lts-8.11
+resolver: nbo-front.yaml
 compiler: ghcjs-0.2.1.9008011_ghc-8.0.2
 compiler-check: match-exact
-
 setup-info:
   ghcjs:
     source:
       ghcjs-0.2.1.9008011_ghc-8.0.2:
         url: https://github.com/matchwood/ghcjs-stack-dist/raw/master/ghcjs-0.2.1.9008011.tar.gz
         sha1: a72a5181124baf64bcd0e68a8726e65914473b3b
-
 ghc-options:
   node-editor: -DGHCJS_BROWSER
   text-editor: -DGHCJS_BROWSER
-extra-deps:
-  - cond-0.4.1.1
-  - datetime-0.3.1
-  - ghcjs-dom-0.7.0.4
-  - ghcjs-dom-jsffi-0.7.0.4
-  - foundation-0.0.7
 
 packages:
-- {location: ./node-editor}
-- {location: ./text-editor}
-- {extra-dep: true, location: ./lib}
-- {extra-dep: true, location: ./node-editor-view}
-- {extra-dep: true, location: ../libs/luna-studio-common}
-- extra-dep: true
-  location: {commit: 61ff909efd466735cd4820f9ab2c564e324b5546, git: 'git@github.com:luna/container.git'}
-- extra-dep: true
-  location: {commit: b84f6fcc7b466760327b1d0f2e7150d9f78dfdc6, git: 'git@github.com:luna/convert.git'}
-- extra-dep: true
-  location: {commit: a6afda3b96efe00938aba61ac12a2f5f2134ff3d, git: 'git@github.com:luna/data-construction.git'}
-- extra-dep: true
-  location: {commit: 8a5773adba33d71a311ba0b4123b744213b0be91, git: 'git@github.com:luna/data-layer.git'}
-- extra-dep: true
-  location: {commit: b5f02ced2912501d923c07950789fbcf44a6a9ce, git: 'git@github.com:luna/data-prop.git'}
-- extra-dep: true
-  location: {commit: 9da4c9b2534693cfe82adeb37f12eaadacb41e62, git: 'git@github.com:luna/data-repr.git'}
-- extra-dep: true
-  location: {commit: 4f5153aed4944317942ff9025c79f7fc3be85181, git: 'git@github.com:luna/data-rtuple.git'}
-- extra-dep: true
-  location: {commit: 8c3d63bb78c24fcfadd22efe1a0b8071c4240ff6, git: 'git@github.com:luna/dependent-state.git'}
-- extra-dep: true
-  location: {commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223, git: 'git@github.com:luna/functor-utils.git'}
-- extra-dep: true
-  location: {commit: 758f81a9914f46efa9137562b0a5ca3df9ce0661, git: 'git@github.com:luna/fuzzy-text.git'}
-- extra-dep: true
-  location: {commit: a1606cccc12cb521acbc598e52c481b9054b42a7, git: 'git@github.com:luna/impossible.git'}
-- extra-dep: true
-  location: {commit: 3ba7d5da78aab023fc74c44fc7445ffab0bc18e0, git: 'git@github.com:luna/lens-utils.git'}
-- extra-dep: true
-  location: {commit: 9c5d7adce748594b0ba1d86fa30ba6f140901c13, git: 'git@github.com:luna/luna.git'}
-  subdirs: [syntax/text/lexer]
-- extra-dep: true
-  location: {commit: e63e373d67cd8dd7c179a618f5d32f6ffb3abdd3, git: 'git@github.com:luna/monoid'}
-- extra-dep: true
-  location: {commit: 7c7a6d657e7db8c3dcd80fbed0a7e02e02f43ae3, git: 'git@github.com:luna/monad-branch'}
-- extra-dep: true
-  location: {commit: cbcd88c87e8888ebfeacd258cca96b3d6d489d35, git: 'git@github.com:luna/parsert'}
-- extra-dep: true
-  location: {commit: c1c525d71b5e749f24e26f71d2d1a68019cae850, git: 'git@github.com:luna/prologue.git'}
-- extra-dep: true
-  location: {commit: ad94b1f2e4bc87b81853ff746b64c59b3eae7f09, git: 'git@github.com:luna/react-flux'}
-- extra-dep: true
-  location: {commit: fe9834f3f5583086d76b12779a1c2a5290c72b0d, git: 'git@github.com:luna/text-processing.git'}
-- extra-dep: true
-  location: {commit: 107db9368e95e192d70c0dec274ecfe3592101d2, git: 'git@github.com:luna/typelevel.git'}
-- extra-dep: true
-  location: {commit: ed546316cdd896467276913a45073a0cb9e447b2, git: 'git@github.com:luna/vector-text.git'}
-- extra-dep: true
-  location: {commit: ddfcd1e0372b93e947b380b911c123fe67227b21, git: 'git@github.com:luna/visualization-api.git'}
+- ./node-editor
+- ./text-editor
+- ./lib
+- ./node-editor-view
+- ../libs/luna-studio-common


### PR DESCRIPTION
Motivation: https://www.fpcomplete.com/blog/2017/07/stacks-new-extensible-snapshots

This pull request moves git-dependencies to new file, nbo.yaml (or nbo-front.yaml) that defines a new Stackage snapshot based on lts-9.21 containing our libs.

This way, our repeated builds are a tad bit faster. As seen here,
```
stack build --stack-yaml build-config/backend/stack.yaml --copy-bins --no-run-tests --no-run-benchmarks -j1 --ghc-options=-j1 --ghc-options="+RTS -M3G -RTS" +RTS -N1 -RTS

RSA-2.2.0: unregistering
authenticate-oauth-1.6: unregistering
batch-lib-luna-empire-0.1.0.0: unregistering
batch-lib-request-monitor-0.1.0.0: unregistering
crypto-api-0.13.2: unregistering
entropy-0.3.7: unregistering
lib-ws-connector-0.1.0.0: unregistering
luna-empire-0.1: unregistering
luna-project-0.1: unregistering
luna-stdlib-0.1: unregistering
pureMD5-2.1.3: unregistering
undo-redo-0.1.0.0: unregistering
uuid-1.3.13: unregistering
websockets-0.10.0.0: unregistering
wuss-1.1.3: unregistering
```
for unknown reasons, stack decides to unregister a few of dependencies each time the project is rebuilt, wasting time. I discovered that updating LTS version resolves that.

In addition, passing `--force-dirty` to stack won't trigger a rebuild of our git-dependencies, saving even more time when we decide that rebuilding a project from scratch is necessary.

**Be aware that this is a BREAKING CHANGE in stack.yaml format and requires stack 1.6.1 or newer**