### PR TITLE
Reset visualizations when node is reset

### DIFF
--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic.hs
@@ -1,5 +1,6 @@
 module NodeEditor.Action.Basic
-    ( addPort
+    ( NodeUpdateModification (KeepPorts, KeepNodeMeta)
+    , addPort
     , addSubgraph
     , centerGraph
     , collapseToFunction
@@ -44,12 +45,10 @@ module NodeEditor.Action.Basic
     , localUnmerge
     , localUpdateConnection
     , localUpdateExpressionNode
-    , localUpdateExpressionNodePreventingPorts
     , localUpdateExpressionNodes
     , localUpdateInputNode
     , localUpdateNodeTypecheck
     , localUpdateOrAddExpressionNode
-    , localUpdateOrAddExpressionNodePreventingPorts
     , localUpdateOrAddInputNode
     , localUpdateOrAddOutputNode
     , localUpdateOutputNode
@@ -83,11 +82,9 @@ module NodeEditor.Action.Basic
     , setInputSidebarPortMode
     , setNodeExpression
     , setNodeMeta
-    , setNodeProfilingData
     , setNodesMeta
     , setOutputSidebarPortMode
     , setPortDefault
-    , setVisualizationData
     , toggleSelect
     , toggleSelectedNodesMode
     , toggleSelectedNodesUnfold
@@ -143,11 +140,11 @@ import           NodeEditor.Action.Basic.SetPortMode         (setInputSidebarPor
 import           NodeEditor.Action.Basic.Undo                (redo, undo)
 import           NodeEditor.Action.Basic.UpdateCollaboration (updateClient, updateCollaboration)
 import           NodeEditor.Action.Basic.UpdateConnection    (localUpdateConnection, updateConnection)
-import           NodeEditor.Action.Basic.UpdateNode          (localUpdateExpressionNode, localUpdateExpressionNodePreventingPorts,
+import           NodeEditor.Action.Basic.UpdateNode          (NodeUpdateModification (KeepNodeMeta, KeepPorts), localUpdateExpressionNode,
                                                               localUpdateExpressionNodes, localUpdateInputNode, localUpdateNodeTypecheck,
-                                                              localUpdateOrAddExpressionNode, localUpdateOrAddExpressionNodePreventingPorts,
-                                                              localUpdateOrAddInputNode, localUpdateOrAddOutputNode, localUpdateOutputNode)
-import           NodeEditor.Action.Basic.UpdateNodeValue     (setNodeProfilingData, setVisualizationData, updateNodeValueAndVisualization)
+                                                              localUpdateOrAddExpressionNode, localUpdateOrAddInputNode,
+                                                              localUpdateOrAddOutputNode, localUpdateOutputNode)
+import           NodeEditor.Action.Basic.UpdateNodeValue     (updateNodeValueAndVisualization)
 import           NodeEditor.Action.Basic.UpdateSearcherHints (localAddSearcherHints, localClearSearcherHints, localUpdateSearcherHints,
                                                               selectHint, setCurrentImports, updateDocs)
 import           NodeEditor.Action.State.Model               (isArgConstructorConnectSrc, updateAllPortsMode, updateArgConstructorMode,

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/AddNode.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/AddNode.hs
@@ -3,31 +3,31 @@ module NodeEditor.Action.Basic.AddNode where
 
 import           Common.Prelude
 
-import qualified Data.Text                               as Text
-import qualified LunaStudio.Data.Node                    as Empire
-import qualified NodeEditor.Action.Batch                 as Batch
-import qualified NodeEditor.Action.State.NodeEditor      as NodeEditor
+import qualified Data.Text                            as Text
+import qualified LunaStudio.Data.Node                 as Empire
+import qualified NodeEditor.Action.Batch              as Batch
+import qualified NodeEditor.Action.State.NodeEditor   as NodeEditor
 
-import           Common.Action.Command                   (Command)
-import           Data.Text                               (Text)
-import           LunaStudio.Data.Geometry                (snap)
-import           LunaStudio.Data.LabeledTree             (LabeledTree (LabeledTree))
-import           LunaStudio.Data.NodeMeta                (NodeMeta (NodeMeta))
-import           LunaStudio.Data.Port                    (InPortIndex (Arg), Port (Port), PortState (NotConnected))
-import           LunaStudio.Data.Position                (Position)
-import           LunaStudio.Data.TypeRep                 (TypeRep (TStar))
-import           NodeEditor.Action.Basic.FocusNode       (focusNode)
-import           NodeEditor.Action.Basic.SelectNode      (selectNode)
-import           NodeEditor.Action.Basic.UpdateNodeValue (setVisualizationData)
-import           NodeEditor.Action.State.Model           (calculatePortSelfMode)
-import           NodeEditor.Action.State.NodeEditor      (addInputNode, addOutputNode, getSelectedNodes, updateNodeVisualizers)
-import           NodeEditor.Action.UUID                  (getUUID)
-import           NodeEditor.React.Model.Node             (ExpressionNode, InputNode, NodeLoc (NodeLoc), NodePath, OutputNode, inPortAt,
-                                                          inPortsList, nodeLoc)
-import           NodeEditor.React.Model.NodeEditor       (VisualizationBackup (MessageBackup))
-import           NodeEditor.React.Model.Port             (isSelf, mode, portId)
-import           NodeEditor.React.Model.Visualization    (awaitingDataMsg)
-import           NodeEditor.State.Global                 (State)
+import           Common.Action.Command                (Command)
+import           Data.Text                            (Text)
+import           LunaStudio.Data.Geometry             (snap)
+import           LunaStudio.Data.LabeledTree          (LabeledTree (LabeledTree))
+import           LunaStudio.Data.NodeMeta             (NodeMeta (NodeMeta))
+import           LunaStudio.Data.Port                 (InPortIndex (Arg), Port (Port), PortState (NotConnected))
+import           LunaStudio.Data.Position             (Position)
+import           LunaStudio.Data.TypeRep              (TypeRep (TStar))
+import           NodeEditor.Action.Basic.FocusNode    (focusNode)
+import           NodeEditor.Action.Basic.SelectNode   (selectNode)
+import           NodeEditor.Action.State.Model        (calculatePortSelfMode)
+import           NodeEditor.Action.State.NodeEditor   (addInputNode, addOutputNode, getSelectedNodes, setVisualizationData,
+                                                       updateNodeVisualizers)
+import           NodeEditor.Action.UUID               (getUUID)
+import           NodeEditor.React.Model.Node          (ExpressionNode, InputNode, NodeLoc (NodeLoc), NodePath, OutputNode, inPortAt,
+                                                       inPortsList, nodeLoc)
+import           NodeEditor.React.Model.NodeEditor    (VisualizationBackup (MessageBackup))
+import           NodeEditor.React.Model.Port          (isSelf, mode, portId)
+import           NodeEditor.React.Model.Visualization (awaitingDataMsg)
+import           NodeEditor.State.Global              (State)
 
 
 createNode :: NodePath -> Position -> Text -> Bool -> Command State ()

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/CreateGraph.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/CreateGraph.hs
@@ -33,7 +33,7 @@ updateGraph nodes input output connections monads = do
     let nlsSet = Set.fromList $ map (view nodeLoc) nodes
     nlsToRemove <- filter (not . flip Set.member nlsSet) . map (view nodeLoc) <$> getExpressionNodes
     void $ localRemoveNodes nlsToRemove
-    mapM_ localUpdateOrAddExpressionNode nodes
+    mapM_ (localUpdateOrAddExpressionNode def) nodes
 
     case input of
         Nothing -> modifyNodeEditor $ NE.inputNode .= def

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
@@ -1,31 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NodeEditor.Action.Basic.UpdateNodeValue where
 
-import Common.Prelude
-
-
-import qualified Data.Map                                   as Map
+import           Common.Action.Command                      (Command)
+import           Common.Prelude
 import qualified Data.Text                                  as Text
-import qualified NodeEditor.React.Model.Node.ExpressionNode as Node
+import           LunaStudio.Data.Error                      (errorContent)
+import           LunaStudio.Data.NodeValue                  (NodeValue (NodeError, NodeValue))
+import           NodeEditor.Action.State.NodeEditor         (getExpressionNodeType, getVisualizersForType, modifyExpressionNode,
+                                                             setVisualizationData)
+import           NodeEditor.React.Model.Node.ExpressionNode (NodeLoc, Value (Error, ShortValue), value)
+import           NodeEditor.React.Model.NodeEditor          (VisualizationBackup (ErrorBackup, MessageBackup, StreamBackup, ValueBackup))
+import           NodeEditor.React.Model.Visualization       (VisualizationValue (StreamDataPoint, StreamStart, Value), noDataMsg, noVisMsg)
+import           NodeEditor.State.Global                    (State)
 
-
-import Common.Action.Command                      (Command)
-import JS.Visualizers                             (notifyStreamRestart, sendInternalData, sendStreamDatapoint, sendVisualizationData)
-import LunaStudio.Data.Error                      (errorContent)
-import LunaStudio.Data.NodeValue                  (NodeValue (NodeError, NodeValue))
-import LunaStudio.Data.TypeRep                    (toConstructorRep)
-import NodeEditor.Action.State.NodeEditor         (getExpressionNodeType, getNodeVisualizations, getVisualizationBackup, getVisualizersForType, 
-                                                   modifyExpressionNode, modifyNodeEditor, recoverVisualizations, setErrorVisualization,
-                                                   setPlaceholderVisualization, updateVisualizationsForNode)
-import NodeEditor.React.Model.Node.ExpressionNode (NodeLoc, Value (Error, ShortValue), execTime, value)
-import NodeEditor.React.Model.NodeEditor          (VisualizationBackup (ErrorBackup, MessageBackup, StreamBackup, ValueBackup), backupMap,
-                                                   visualizationsBackup, _StreamBackup)
-import NodeEditor.React.Model.Visualization       (VisualizationValue (StreamDataPoint, StreamStart, Value), noDataMsg, noVisMsg, visualizations,
-                                                   visualizations)
-import NodeEditor.State.Global                    (State)
-
-
-import NodeEditor.Action.State.NodeEditor         (getExpressionNode)
 
 updateNodeValueAndVisualization :: NodeLoc -> NodeValue -> Command State ()
 updateNodeValueAndVisualization nl = \case
@@ -40,41 +27,9 @@ updateNodeValueAndVisualization nl = \case
         setVisualizationData nl (StreamBackup []) True
     NodeValue sv Nothing -> do
         modifyExpressionNode nl $ value .= ShortValue (Text.take 100 sv)
-        hasVisualizers <- maybe (return False) (fmap isJust . getVisualizersForType) =<< getExpressionNodeType nl
-        let msg = if hasVisualizers then noDataMsg else noVisMsg
+        noVisualizers <- maybe (return False) (fmap isNothing . getVisualizersForType) =<< getExpressionNodeType nl
+        let msg = if noVisualizers then noVisMsg else noDataMsg
         setVisualizationData nl (MessageBackup msg) True
     NodeError e -> do
         modifyExpressionNode nl $ value .= Error e
         setVisualizationData nl (ErrorBackup $ e ^. errorContent) True
-
-
-setNodeProfilingData :: NodeLoc -> Integer -> Command State ()
-setNodeProfilingData nl t = modifyExpressionNode nl $ execTime ?= t
-
-isNewData :: NodeLoc -> VisualizationBackup -> Command State Bool
-isNewData nl vp = (Just vp /=) <$> getVisualizationBackup nl 
-
-setVisualizationData :: NodeLoc -> VisualizationBackup -> Bool -> Command State ()
-setVisualizationData nl backup@(ValueBackup val) overwrite = whenM ((overwrite ||) <$> isNewData nl backup) $ do
-    modifyNodeEditor $ visualizationsBackup . backupMap . at nl ?= backup
-    visIds <- updateVisualizationsForNode nl
-    withJustM (maybe def toConstructorRep <$> getExpressionNodeType nl) $ \cRep ->
-        liftIO . forM_ visIds $ \visId -> sendVisualizationData visId cRep val
-setVisualizationData nl backup@(StreamBackup values) overwrite@True = whenM (isNewData nl backup) $ do
-    modifyNodeEditor $ visualizationsBackup . backupMap . at nl ?= backup
-    visIds <- updateVisualizationsForNode nl
-    withJustM (maybe def toConstructorRep <$> getExpressionNodeType nl) $ \cRep ->
-        liftIO . forM_ visIds $ \visId -> notifyStreamRestart visId cRep $ reverse values
-setVisualizationData nl backup@(StreamBackup values) overwrite@False = do
-    modifyNodeEditor $ visualizationsBackup . backupMap . ix nl . _StreamBackup %= (values <>)
-    visIds <- maybe def (Map.keys . view visualizations) <$> getNodeVisualizations nl
-    liftIO . forM_ visIds $ forM_ values . sendStreamDatapoint
-setVisualizationData nl backup@(MessageBackup msg) overwrite = whenM ((overwrite ||) <$> isNewData nl backup) $ do
-    modifyNodeEditor $ visualizationsBackup . backupMap . at nl ?= backup
-    visIds <- setPlaceholderVisualization nl
-    liftIO . forM_ visIds $ flip sendInternalData msg
-setVisualizationData nl backup@(ErrorBackup msg) overwrite = whenM ((overwrite ||) <$> isNewData nl backup) $ do
-    modifyNodeEditor $ visualizationsBackup . backupMap . at nl ?= backup
-    visIds <- setErrorVisualization nl
-    liftIO . forM_ visIds $ flip sendInternalData msg
-


### PR DESCRIPTION
There was a problem that sometimes placeholder hasn't change despite on node being gray out (which indicates that we know nothing and we wait for info from backend). This also fix a problem where too fast clicking on Next button in tutorial causes unwanted visualization toggle - it was happening because of delayed responses from backend that caries outdated informations.