### PR TITLE
Set correct CWD for value representation computations

### DIFF
--- a/libs/luna-empire/src/Empire/Commands/Typecheck.hs
+++ b/libs/luna-empire/src/Empire/Commands/Typecheck.hs
@@ -56,6 +56,7 @@ import qualified Luna.Pass.Evaluation.Interpreter as Interpreter
 import           Luna.Pass.Resolution.Data.CurrentTarget (CurrentTarget(TgtDef))
 import qualified Luna.IR.Layer.Errors             as Errors
 import           OCI.IR.Name.Qualified            (QualName)
+import qualified System.IO as IO
 
 runTC :: QualName -> String -> Imports -> Command Graph ()
 runTC moduleName functionName imports = do
@@ -66,9 +67,14 @@ runTC moduleName functionName imports = do
         Graph.breadcrumbHierarchy . BH.refs %= (\x -> Map.findWithDefault x x mapping)
     return ()
 
+withProjectCurrentDirectory :: FilePath -> IO a -> IO a
+withProjectCurrentDirectory currentFile act = do
+    rootPath <- liftIO $ Project.findProjectRootForFile =<< Path.parseAbsFile currentFile
+    let projectDirectory = maybe (takeDirectory currentFile) Path.toFilePath rootPath
+    withCurrentDirectory projectDirectory act
+
 runInterpreter :: FilePath -> Imports -> Command Graph (Maybe Interpreter.LocalScope)
 runInterpreter path imports = runASTOp $ do
-    rootPath <- liftIO $ Project.findProjectRootForFile =<< Path.parseAbsFile path
     selfRef  <- use $ Graph.breadcrumbHierarchy . BH.self
     IR.matchExpr selfRef $ \case
         IR.ASGFunction _ [] b -> do
@@ -76,7 +82,7 @@ runInterpreter path imports = runASTOp $ do
             res     <- Interpreter.interpret' imports . IR.unsafeGeneralize $ bodyRef
             mask_ $ liftIO $ do
                 ref <- IORef.newIORef def
-                withCurrentDirectory (maybe (takeDirectory path) Path.toFilePath rootPath)
+                withProjectCurrentDirectory path
                     $ runIO $ runError $ execStateT (Interpreter.unScopeT res) ref
                 Just <$> IORef.readIORef ref
         _ -> return Nothing
@@ -112,7 +118,7 @@ updateMonads loc@(GraphLocation _ br) = return ()
 updateValues :: GraphLocation
              -> Interpreter.LocalScope
              -> Command Graph [Async ()]
-updateValues loc scope = do
+updateValues loc@(GraphLocation path _) scope = do
     childrenMap <- use $ Graph.breadcrumbHierarchy . BH.children
     let allNodes = Map.assocs $ view BH.self <$> childrenMap
     env     <- ask
@@ -134,15 +140,16 @@ updateValues loc scope = do
         sendStreamRep nid (SuccessRep s l) = send nid
                                            $ NodeValue (convert s)
                                            $ StreamDataPoint . convert <$> l
-    asyncs <- forM allVars $ \(nid, ref) -> do
-        let resVal = Interpreter.localLookup (IR.unsafeGeneralize ref) scope
-        liftIO $ forM resVal $ \v -> do
-            value <- getReps v
-            case value of
-                OneTime r   -> Async.async $ sendRep nid r
-                Streaming f -> do
-                    send nid (NodeValue "Stream" $ Just StreamStart)
-                    Async.async (f (sendStreamRep nid))
+    asyncs <- liftIO $ withProjectCurrentDirectory path $
+        forM allVars $ \(nid, ref) -> do
+            let resVal = Interpreter.localLookup (IR.unsafeGeneralize ref) scope
+            forM resVal $ \v -> do
+                value <- getReps v
+                case value of
+                    OneTime r   -> Async.async $ sendRep nid r
+                    Streaming f -> do
+                        send nid (NodeValue "Stream" $ Just StreamStart)
+                        Async.async (f (sendStreamRep nid))
     return $ catMaybes asyncs
 
 flushCache :: Command InterpreterEnv ()

--- a/libs/luna-empire/src/Empire/Commands/Typecheck.hs
+++ b/libs/luna-empire/src/Empire/Commands/Typecheck.hs
@@ -56,7 +56,6 @@ import qualified Luna.Pass.Evaluation.Interpreter as Interpreter
 import           Luna.Pass.Resolution.Data.CurrentTarget (CurrentTarget(TgtDef))
 import qualified Luna.IR.Layer.Errors             as Errors
 import           OCI.IR.Name.Qualified            (QualName)
-import qualified System.IO as IO
 
 runTC :: QualName -> String -> Imports -> Command Graph ()
 runTC moduleName functionName imports = do


### PR DESCRIPTION
One example of this backfiring was when a C function was used inside `toJSON` – the CWD was not set to the project dir and thus the C binding could not be resolved. This PR fixes this behavior.