### PR TITLE
WS rework

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.2
+resolver: lts-8.20
 ghc-options:
   '*': -threaded -fconstraint-solver-iterations=100 -O2
 local-bin-path:
@@ -18,6 +18,8 @@ extra-deps:
 - shelly-1.6.8.4
 - serialport-0.4.7
 - uuid-1.3.13
+- websockets-0.12.3.1
+- wuss-1.1.9
 
 packages:
 - {extra-dep: false, location: ../../libs/luna-empire}

--- a/env/config/luna-ws.config
+++ b/env/config/luna-ws.config
@@ -1,5 +1,6 @@
 websocket {
-    host     = "0.0.0.0"
-    port     = "30533"
-    pingTime = "30"
+    host        = "0.0.0.0"
+    fromWebPort = "30533"
+    toWebPort   = "30534"
+    pingTime    = "30"
 }

--- a/libs/ws-connector/package.yaml
+++ b/libs/ws-connector/package.yaml
@@ -6,6 +6,8 @@ maintainer:          contact@nodelab.io
 
 default-extensions:
   - NoImplicitPrelude
+  - Strict
+  - StrictData
 
 library:
   source-dirs: src
@@ -21,10 +23,11 @@ dependencies:
   - either
   - exceptions
   - m-logger
+  - random
   - mtl
   - prologue
-  - stm
   - text
+  - unagi-chan
   - websockets
   - zeromq4-haskell
   - zmq-bus

--- a/libs/ws-connector/src/WSConnector/Data/WSFrame.hs
+++ b/libs/ws-connector/src/WSConnector/Data/WSFrame.hs
@@ -8,7 +8,6 @@ module WSConnector.Data.WSFrame where
 
 import qualified Data.Binary                 as Binary
 import           Data.ByteString             (ByteString)
-import           Data.ByteString.Base64.Lazy (decodeLenient, encode)
 import           Data.ByteString.Lazy        (fromStrict, toStrict)
 import           Prologue
 
@@ -21,8 +20,8 @@ makeLenses ''WSFrame
 instance Binary.Binary WSFrame
 
 deserializeFrame :: ByteString -> WSFrame
-deserializeFrame = Binary.decode . decodeLenient . fromStrict
+deserializeFrame = Binary.decode . fromStrict
 
 serializeFrame :: WSFrame -> ByteString
-serializeFrame = toStrict . encode . Binary.encode
+serializeFrame = toStrict . Binary.encode
 

--- a/libs/ws-connector/src/WSConnector/WSConfig.hs
+++ b/libs/ws-connector/src/WSConnector/WSConfig.hs
@@ -5,15 +5,17 @@ module WSConnector.WSConfig where
 import           Prologue
 import qualified ZMQ.Bus.WS.Config as FD
 
-data Config = Config { _host     :: String
-                     , _port     :: Int
-                     , _pingTime :: Int
+data Config = Config { _host        :: String
+                     , _fromWebPort :: Int
+                     , _toWebPort   :: Int
+                     , _pingTime    :: Int
                      } deriving (Read, Show, Eq)
 
 makeLenses ''Config
 
-readWebsocketConfig config = Config host port pingTime where
-    host       = FD.host websocket
-    port       = unsafeRead (FD.port websocket) :: Int
-    pingTime   = unsafeRead (FD.pingTime websocket) :: Int
-    websocket  = FD.websocket config
+readWebsocketConfig config = Config host fromWebPort toWebPort pingTime where
+    host        = FD.host websocket
+    fromWebPort = unsafeRead (FD.fromWebPort websocket)
+    toWebPort   = unsafeRead (FD.toWebPort   websocket)
+    pingTime    = unsafeRead (FD.pingTime    websocket)
+    websocket   = FD.websocket config

--- a/libs/ws-connector/src/WSConnector/WSConfig.hs
+++ b/libs/ws-connector/src/WSConnector/WSConfig.hs
@@ -3,19 +3,20 @@
 module WSConnector.WSConfig where
 
 import           Prologue
-import qualified ZMQ.Bus.WS.Config as FD
+import qualified ZMQ.Bus.WS.Config as WSConfig
 
-data Config = Config { _host        :: String
-                     , _fromWebPort :: Int
-                     , _toWebPort   :: Int
-                     , _pingTime    :: Int
-                     } deriving (Read, Show, Eq)
+data Config = Config
+    { _host        :: String
+    , _fromWebPort :: Int
+    , _toWebPort   :: Int
+    , _pingTime    :: Int
+    } deriving (Read, Show, Eq)
 
 makeLenses ''Config
 
 readWebsocketConfig config = Config host fromWebPort toWebPort pingTime where
-    host        = FD.host websocket
-    fromWebPort = unsafeRead (FD.fromWebPort websocket)
-    toWebPort   = unsafeRead (FD.toWebPort   websocket)
-    pingTime    = unsafeRead (FD.pingTime    websocket)
-    websocket   = FD.websocket config
+    host        = WSConfig.host websocket
+    fromWebPort = unsafeRead (WSConfig.fromWebPort websocket)
+    toWebPort   = unsafeRead (WSConfig.toWebPort   websocket)
+    pingTime    = unsafeRead (WSConfig.pingTime    websocket)
+    websocket   = WSConfig.websocket config

--- a/libs/ws-connector/src/WSConnector/WSConnector.hs
+++ b/libs/ws-connector/src/WSConnector/WSConnector.hs
@@ -41,7 +41,7 @@ application clientCounter currentClient pingTime toBusChan fromBusChan pending =
     WS.forkPingThread conn pingTime
 
     let welcomeMessage = serializeFrame $ WSFrame [ControlMessage Welcome]
-    WS.sendTextData conn welcomeMessage
+    WS.sendBinaryData conn welcomeMessage
 
     fromBusListenChan <- atomically $ dupTChan fromBusChan
 
@@ -64,14 +64,14 @@ fromWeb :: Int -> TVar Int -> WS.Connection -> TChan WSMessage -> TChan WSMessag
 fromWeb clientId currentClient conn chan wsChan = do
     flip catch handleDisconnect $ fromWebLoop clientId currentClient conn chan wsChan
     let takeoverMessage = serializeFrame $ WSFrame [ControlMessage ConnectionTakeover]
-    WS.sendTextData conn takeoverMessage
-    WS.sendClose    conn takeoverMessage
+    WS.sendBinaryData conn takeoverMessage
+    WS.sendClose      conn takeoverMessage
 
 toWeb :: WS.Connection -> TChan WSMessage -> IO ()
 toWeb conn chan = flip catch handleDisconnect $ forever $ do
     msg <- atomically $ readTChan chan
     let webMessage = serializeFrame $ WSFrame [msg]
-    WS.sendTextData conn webMessage
+    WS.sendBinaryData conn webMessage
 
 run :: BusEndPoints -> WSConfig.Config -> IO ()
 run busEndPoints config = do

--- a/libs/ws-connector/src/WSConnector/WSConnector.hs
+++ b/libs/ws-connector/src/WSConnector/WSConnector.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE BangPatterns    #-}
 
 module WSConnector.WSConnector where
 
@@ -7,9 +8,8 @@ import           Prologue
 import           System.Log.MLogger
 
 import           Control.Concurrent            (forkIO)
-import           Control.Concurrent.STM        (STM, atomically)
-import           Control.Concurrent.STM.TChan
-import           Control.Concurrent.STM.TVar
+import qualified Control.Concurrent.MVar       as MVar
+import qualified Control.Concurrent.Chan.Unagi as Unagi
 import           Control.Monad                 (forever)
 import qualified Data.ByteString               as ByteString
 import qualified Network.WebSockets            as WS
@@ -21,65 +21,87 @@ import           WSConnector.Data.WSMessage    (ControlCode (..), WSMessage (..)
 import qualified WSConnector.Workers.BusWorker as BusWorker
 import qualified WSConnector.WSConfig          as WSConfig
 
+import qualified System.CPUTime                as CPUTime
+
 logger :: Logger
 logger = getLogger $moduleName
+
+timed :: IO a -> IO Double
+timed act = do
+    t0 <- CPUTime.getCPUTime
+    act
+    t1 <- CPUTime.getCPUTime
+    return $ fromIntegral (t1 - t0) * 1e-12
 
 handleDisconnect :: WS.ConnectionException -> IO ()
 handleDisconnect _ = logger info "User disconnected"
 
-getFreshClientId :: TVar Int -> TVar Int -> STM Int
-getFreshClientId clientCounter currentClient = do
-    modifyTVar clientCounter (+ 1)
-    newId <- readTVar clientCounter
-    writeTVar currentClient newId
-    return newId
+fromWebApp :: Int -> Unagi.InChan WSMessage -> WS.ServerApp
+fromWebApp pingTime toBusChan pending = do
+    conn <- WS.acceptRequest pending
+    WS.forkPingThread conn pingTime
 
-application :: TVar Int -> TVar Int -> Int -> TChan WSMessage -> TChan WSMessage -> WS.ServerApp
-application clientCounter currentClient pingTime toBusChan fromBusChan pending = do
-    newId <- atomically $ getFreshClientId clientCounter currentClient
+    fromWeb conn toBusChan
+
+toWebApp :: Int -> Unagi.InChan WSMessage -> WS.ServerApp
+toWebApp pingTime fromBusChan pending = do
     conn <- WS.acceptRequest pending
     WS.forkPingThread conn pingTime
 
     let welcomeMessage = serializeFrame $ WSFrame [ControlMessage Welcome]
     WS.sendBinaryData conn welcomeMessage
 
-    fromBusListenChan <- atomically $ dupTChan fromBusChan
-
-    forkIO $ fromWeb newId clientCounter conn toBusChan fromBusChan
+    fromBusListenChan <- Unagi.dupChan fromBusChan
     toWeb conn fromBusListenChan
 
-whileActive :: Int -> TVar Int -> IO () -> IO ()
-whileActive clientId currentClient action = do
-    action
-    whileActive clientId currentClient action
-
-fromWebLoop :: Int -> TVar Int -> WS.Connection -> TChan WSMessage -> TChan WSMessage -> IO ()
-fromWebLoop clientId currentClient conn chan wsChan = whileActive clientId currentClient $ do
+fromWebLoop :: WS.Connection -> Unagi.InChan WSMessage -> IO ()
+fromWebLoop conn chan = forever $ do
     webMessage <- WS.receiveData conn
     let frame = deserializeFrame webMessage
-    atomically $ mapM_ (writeTChan chan) $ frame ^. messages
-    atomically $ mapM_ (writeTChan wsChan) $ frame ^. messages
+    mapM_ (Unagi.writeChan chan) $ frame ^. messages
 
-fromWeb :: Int -> TVar Int -> WS.Connection -> TChan WSMessage -> TChan WSMessage -> IO ()
-fromWeb clientId currentClient conn chan wsChan = do
-    flip catch handleDisconnect $ fromWebLoop clientId currentClient conn chan wsChan
+fromWeb :: WS.Connection -> Unagi.InChan WSMessage -> IO ()
+fromWeb conn chan = do
+    flip catch handleDisconnect $ fromWebLoop conn chan
     let takeoverMessage = serializeFrame $ WSFrame [ControlMessage ConnectionTakeover]
-    WS.sendBinaryData conn takeoverMessage
-    WS.sendClose      conn takeoverMessage
+    WS.sendClose conn takeoverMessage
 
-toWeb :: WS.Connection -> TChan WSMessage -> IO ()
-toWeb conn chan = flip catch handleDisconnect $ forever $ do
-    msg <- atomically $ readTChan chan
-    let webMessage = serializeFrame $ WSFrame [msg]
-    WS.sendBinaryData conn webMessage
+toWebLoop :: WS.Connection -> Unagi.OutChan WSMessage -> IO ()
+toWebLoop conn chan = forever $ do
+    msg <- Unagi.readChan chan
+    let !webMessage = serializeFrame $ WSFrame [msg]
+        len = ByteString.length webMessage
+    logger info $ "Sending " <> show len <> " bytes."
+    t <- timed $ WS.sendBinaryData conn webMessage
+    let mbps = floor $ fromIntegral len * 1e-6 / t
+    logger info $ "Sent " <> show len <> " bytes at " <> show mbps <> " MB/s."
+
+toWeb :: WS.Connection -> Unagi.OutChan WSMessage -> IO ()
+toWeb conn chan = do
+    flip catch handleDisconnect $ toWebLoop conn chan
+    let takeoverMessage = serializeFrame $ WSFrame [ControlMessage ConnectionTakeover]
+    WS.sendClose conn takeoverMessage
+
+sinkChan :: Unagi.OutChan a -> IO ()
+sinkChan c = forever $ do
+    !a <- Unagi.readChan c
+    return ()
 
 run :: BusEndPoints -> WSConfig.Config -> IO ()
 run busEndPoints config = do
-    toBusChan       <- atomically newTChan
-    fromBusChan     <- atomically newBroadcastTChan
-    clientCounter   <- atomically $ newTVar 0
-    currentClient   <- atomically $ newTVar 0
+    (toBusIn, toBusOut)     <- Unagi.newChan
+    (fromBusIn, fromBusOut) <- Unagi.newChan
 
-    BusWorker.start busEndPoints fromBusChan toBusChan
+    BusWorker.start busEndPoints fromBusIn toBusOut
 
-    WS.runServer (config ^. WSConfig.host) (config ^. WSConfig.port) $ application clientCounter currentClient (config ^. WSConfig.pingTime) toBusChan fromBusChan
+    let host        = config ^. WSConfig.host
+        fromWebPort = config ^. WSConfig.fromWebPort
+        toWebPort   = config ^. WSConfig.toWebPort
+        pingTime    = config ^. WSConfig.pingTime
+
+    -- We need this to flush data from the unused end of this channel.
+    -- Actual read ends are created with `Unagi.dupChan`, per-client.
+    forkIO $ sinkChan fromBusOut
+
+    forkIO $ WS.runServer host fromWebPort $ fromWebApp pingTime toBusIn
+    WS.runServer host toWebPort $ toWebApp pingTime fromBusIn

--- a/libs/ws-connector/src/WSConnector/Workers/BusWorker.hs
+++ b/libs/ws-connector/src/WSConnector/Workers/BusWorker.hs
@@ -7,9 +7,10 @@ import           Prologue                     hiding (fail)
 import           Prelude                      (fail)
 import           System.Log.MLogger
 
-import           Control.Concurrent           (forkIO)
-import           Control.Concurrent.STM       (atomically)
-import           Control.Concurrent.STM.TChan
+import           Control.Concurrent            (forkIO)
+import qualified Control.Concurrent.Chan.Unagi as Unagi
+import qualified Control.Concurrent.MVar       as MVar
+
 import           Control.Monad                (forever)
 import           ZMQ.Bus.Bus                  (Bus)
 import qualified ZMQ.Bus.Bus                  as Bus
@@ -37,30 +38,30 @@ shouldPassToClient frame clientId = isNotSender where
 --     isNotSender      = senderId /= clientId
 --     senderId         = frame ^. MessageFrame.senderID
 
-fromBus :: TChan WSMessage -> TChan Message.ClientID -> Bus ()
-fromBus chan idChan = do
+fromBus :: Unagi.InChan WSMessage -> MVar.MVar Message.ClientID -> Bus ()
+fromBus chan idVar = do
     mapM_ Bus.subscribe relevantTopics
-    senderAppId <- liftIO $ atomically $ readTChan idChan
+    senderAppId <- liftIO $ MVar.takeMVar idVar
     forever $ do
         frame <- Bus.receive
-        when (shouldPassToClient frame senderAppId) $ do
+        liftIO $ when (shouldPassToClient frame senderAppId) $ do
             let msg = frame ^. MessageFrame.message
-            logger info $ "Received from Bus: " <> (show msg)
-            liftIO $ atomically $ writeTChan chan $ WebMessage (msg ^. Message.topic)
-                                                               (msg ^. Message.message)
+            logger info $ "Received from Bus: " <> (msg ^. Message.topic)
+            Unagi.writeChan chan $ WebMessage (msg ^. Message.topic)
+                                              (msg ^. Message.message)
 
 dispatchMessage :: WSMessage -> Bus ()
 dispatchMessage (WebMessage topic msg) = do
-    logger info $ "Pushing to Bus: " <> (show msg)
+    logger info $ "Pushing to Bus: " <> topic
     void $ Bus.send Flag.Enable $ Message.Message topic msg
 dispatchMessage _ = return ()
 
-toBus :: TChan WSMessage -> TChan Message.ClientID -> Bus ()
-toBus chan idChan = do
+toBus :: Unagi.OutChan WSMessage -> MVar.MVar Message.ClientID -> Bus ()
+toBus chan idVar = do
     myId <- Bus.getClientID
-    liftIO $ atomically $ writeTChan idChan myId
+    liftIO $ MVar.putMVar idVar myId
     forever $ do
-        msg <- liftIO $ atomically $ readTChan chan
+        msg <- liftIO $ Unagi.readChan chan
         dispatchMessage msg
 
 
@@ -70,9 +71,9 @@ eitherToM = either (fail . show) return
 eitherToM' :: (Monad m, Show a) => m (Either a b) -> m b
 eitherToM' action = action >>= eitherToM
 
-start :: BusEndPoints -> TChan WSMessage -> TChan WSMessage -> IO ()
+start :: BusEndPoints -> Unagi.InChan WSMessage -> Unagi.OutChan WSMessage -> IO ()
 start busEndPoints fromBusChan toBusChan = do
-    exchangeIdsChan <- atomically newTChan
-    forkIO $ eitherToM' $ Bus.runBus busEndPoints $ fromBus fromBusChan exchangeIdsChan
-    forkIO $ eitherToM' $ Bus.runBus busEndPoints $ toBus   toBusChan   exchangeIdsChan
+    exchangeIdsVar <- MVar.newEmptyMVar
+    forkIO $ eitherToM' $ Bus.runBus busEndPoints $ fromBus fromBusChan exchangeIdsVar
+    forkIO $ eitherToM' $ Bus.runBus busEndPoints $ toBus   toBusChan   exchangeIdsVar
     return ()

--- a/libs/zmq-bus-config/src/ZMQ/Bus/WS/Config.hs
+++ b/libs/zmq-bus-config/src/ZMQ/Bus/WS/Config.hs
@@ -22,9 +22,10 @@ data Config = Config      { websocket :: Section
                           }
             deriving (Show)
 
-data Section = Websocket   { host     :: String
-                           , port     :: String
-                           , pingTime :: String
+data Section = Websocket   { host        :: String
+                           , fromWebPort :: String
+                           , toWebPort   :: String
+                           , pingTime    :: String
                            }
              deriving (Show)
 
@@ -48,6 +49,7 @@ load = do
 
 
     Config <$> ( Websocket <$> readConf "websocket.host"
-                           <*> readConf "websocket.port"
+                           <*> readConf "websocket.fromWebPort"
+                           <*> readConf "websocket.toWebPort"
                            <*> readConf "websocket.pingTime"
                )

--- a/luna-studio/lib/src/Common/Batch/Connector/Connection.hs
+++ b/luna-studio/lib/src/Common/Batch/Connector/Connection.hs
@@ -4,7 +4,8 @@ module Common.Batch.Connector.Connection where
 import           Common.Prelude              hiding (Text)
 import           Data.Binary                 (Binary)
 import qualified Data.Binary                 as Binary
-import qualified Data.ByteString.Base64.Lazy as Base64
+import qualified Data.ByteString.Lazy        as ByteString
+import qualified Data.ByteString             as Strict
 import           Data.ByteString.Lazy.Char8  (ByteString, pack)
 import           Data.JSString.Text
 import           Data.Text.Lazy.Encoding     (decodeUtf8)
@@ -42,11 +43,11 @@ instance Binary.Binary ControlCode
 instance Binary.Binary WebMessage
 instance Binary.Binary Frame
 
-serialize :: Frame -> JSString
-serialize = lazyTextToJSString . decodeUtf8 . Base64.encode . Binary.encode
+serialize :: Frame -> Strict.ByteString
+serialize = ByteString.toStrict . Binary.encode
 
-deserialize :: String -> Frame
-deserialize = Binary.decode . Base64.decodeLenient . pack
+deserialize :: Strict.ByteString -> Frame
+deserialize = Binary.decode . ByteString.fromStrict
 
 sendMessages :: [WebMessage] -> IO ()
 sendMessages msgs = do

--- a/luna-studio/lib/src/WebSocket.hs
+++ b/luna-studio/lib/src/WebSocket.hs
@@ -69,11 +69,11 @@ foreign import javascript safe "$1.unOnError()"
 foreign import javascript safe "$1.send($2)"
     js_send :: WebSocket -> ArrayBuffer -> IO ()
 
-foreign import javascript safe "$1.connect($2)"
-    connect' :: WebSocket -> JSString -> IO ()
+foreign import javascript safe "$1.connect($2, $3)"
+    connect' :: WebSocket -> JSString -> JSString -> IO ()
 
-connect :: WebSocket -> String -> IO ()
-connect ws addr = connect' ws $ convert addr
+connect :: WebSocket -> String -> String -> IO ()
+connect ws listenAddr sendAddr = connect' ws (convert listenAddr) (convert sendAddr)
 
 getData :: WSMessageEvent -> IO ByteString
 getData = fmap (toByteString 0 Nothing . createFromArrayBuffer) . js_getData

--- a/luna-studio/lib/src/WebSocket.hs
+++ b/luna-studio/lib/src/WebSocket.hs
@@ -13,12 +13,16 @@ module WebSocket (WebSocket
                  , send
                  ) where
 
-import           Data.ByteString        (ByteString)
+import           Data.ByteString                   (ByteString)
 import           Data.JSString
 import           GHCJS.Foreign.Callback
-import           GHCJS.Marshal.Pure     (PFromJSVal (..), PToJSVal (..))
-import           GHCJS.Types            (IsJSVal)
-import           GHCJS.Buffer           (toByteString, createFromArrayBuffer, fromByteString, getArrayBuffer)
+import           GHCJS.Marshal.Pure                ( PFromJSVal (..)
+                                                   , PToJSVal (..))
+import           GHCJS.Types                       (IsJSVal)
+import           GHCJS.Buffer                      ( toByteString
+                                                   , createFromArrayBuffer
+                                                   , fromByteString
+                                                   , getArrayBuffer)
 import           JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
 import           Common.Prelude
 
@@ -73,7 +77,8 @@ foreign import javascript safe "$1.connect($2, $3)"
     connect' :: WebSocket -> JSString -> JSString -> IO ()
 
 connect :: WebSocket -> String -> String -> IO ()
-connect ws listenAddr sendAddr = connect' ws (convert listenAddr) (convert sendAddr)
+connect ws listenAddr sendAddr = connect' ws (convert listenAddr)
+                                             (convert sendAddr)
 
 getData :: WSMessageEvent -> IO ByteString
 getData = fmap (toByteString 0 Nothing . createFromArrayBuffer) . js_getData

--- a/luna-studio/node-editor/config.release.js
+++ b/luna-studio/node-editor/config.release.js
@@ -5,7 +5,10 @@ function defaultBackend() {
     // if(typeof(l) != "undefined")
     //     return ((l.protocol === "https:") ? "wss://" : "ws://") + l.hostname + (((l.port !== 80) && (l.port !== 443)) ? ":" + l.port : "") + "/ws";
     // else
-        return "ws://localhost:30533";
+    return {
+        send: "ws://localhost:30533",
+        listen: "ws://localhost:30534"
+    };
 }
 
 module.exports = {

--- a/luna-studio/node-editor/js/websocket.js
+++ b/luna-studio/node-editor/js/websocket.js
@@ -92,6 +92,7 @@ module.exports = function () {
     },
     connect: function (addr) {
       connection = new WebSocket(addr);
+      connection.binaryType = "arraybuffer";
       attachListeners();
     },
     send: function (data) {

--- a/luna-studio/node-editor/js/websocket.js
+++ b/luna-studio/node-editor/js/websocket.js
@@ -1,35 +1,16 @@
 "use strict";
 
-var removeFromArray = function (array, elt) {
-  var index = array.indexOf(elt);
-  array.splice(index, 1);
-};
-
 var mockSocket = function () {
-  var listeners = [];
-
   return {
-    addEventListener: function (type, lst) {
-      if (type === "message")
-        listeners.push(lst);
-    },
-    removeEventListener: function (type, lst) {
-      if (type === "message")
-        removeFromArray(listeners, lst);
-    },
-    send: function (data) {
-      var decoded = atob(data);
-      var replaced = decoded.replace("request", "fakeres");
-      var fakeResponse = { data: btoa(replaced) };
-      listeners.forEach(function (listener) {
-        listener.call(null, fakeResponse);
-      });
-    }
+    addEventListener: function () {},
+    removeEventListener: function () {},
+    send: function () {}
   };
 };
 
 module.exports = function () {
-  var connection = mockSocket();
+  var listenConnection = mockSocket();
+  var sendConnection   = mockSocket();
   var isConnOpen = false;
   var listeners = {
     onOpen: [],
@@ -40,16 +21,16 @@ module.exports = function () {
 
   var attachListeners = function () {
     listeners.onOpen.forEach(function (listener) {
-      connection.addEventListener("open", listener);
+      listenConnection.addEventListener("open", listener);
     });
     listeners.onMessage.forEach(function (listener) {
-      connection.addEventListener("message", listener);
+      listenConnection.addEventListener("message", listener);
     });
     listeners.onClose.forEach(function (listener) {
-      connection.addEventListener("close", listener);
+      listenConnection.addEventListener("close", listener);
     });
     listeners.onError.forEach(function (listener) {
-      connection.addEventListener("error", listener);
+      listenConnection.addEventListener("error", listener);
     });
   };
 
@@ -60,43 +41,29 @@ module.exports = function () {
     onOpen: function (listener) {
       isConnOpen = true;
       listeners.onOpen.push(listener);
-      connection.addEventListener("open", listener);
-    },
-    unOnOpen: function (listener) {
-      removeFromArray(listeners.onOpen, listener);
-      connection.removeEventListener("open", listener);
+      listenConnection.addEventListener("open", listener);
     },
     onMessage: function (listener) {
       listeners.onMessage.push(listener);
-      connection.addEventListener("message", listener);
-    },
-    unOnMessage: function (listener) {
-      removeFromArray(listeners.onMessage, listener);
-      connection.removeEventListener("message", listener);
+      listenConnection.addEventListener("message", listener);
     },
     onClose: function (listener) {
       listeners.onClose.push(listener);
-      connection.addEventListener("close", listener);
-    },
-    unOnClose: function (listener) {
-      removeFromArray(listeners.onClose, listener);
-      connection.removeEventListener("close", listener);
+      listenConnection.addEventListener("close", listener);
     },
     onError: function (listener) {
       listeners.onError.push(listener);
-      connection.addEventListener("error", listener);
+      listenConnection.addEventListener("error", listener);
     },
-    unOnError: function (listener) {
-      removeFromArray(listeners.onError, listener);
-      connection.removeEventListener("error", listener);
-    },
-    connect: function (addr) {
-      connection = new WebSocket(addr);
-      connection.binaryType = "arraybuffer";
+    connect: function (listenAddr, sendAddr) {
+      listenConnection = new WebSocket(listenAddr);
+      listenConnection.binaryType = "arraybuffer";
+      sendConnection = new WebSocket(sendAddr);
+      sendConnection.binaryType = "arraybuffer"
       attachListeners();
     },
     send: function (data) {
-      connection.send(data);
+      sendConnection.send(data);
     }
   };
 };

--- a/luna-studio/node-editor/src/JS/Config.hs
+++ b/luna-studio/node-editor/src/JS/Config.hs
@@ -9,8 +9,11 @@ import           Common.Prelude
 
 
 
-foreign import javascript safe "config.backendAddress"
-    getBackendAddress' :: IO JSString
+foreign import javascript safe "config.backendAddress.listen"
+    js_getListenAddress :: IO JSString
 
-getBackendAddress :: IO String
-getBackendAddress  = convert <$> getBackendAddress'
+foreign import javascript safe "config.backendAddress.send"
+    js_getSendAddress :: IO JSString
+
+getBackendAddress :: IO (String, String)
+getBackendAddress  = convert .: (,) <$> js_getListenAddress <*> js_getSendAddress

--- a/luna-studio/node-editor/src/NodeEditor/Event/Loader.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/Loader.hs
@@ -9,7 +9,7 @@ import qualified WebSocket                  as WS
 
 withActiveConnection :: (WebSocket -> IO ()) -> IO ()
 withActiveConnection action = do
-    addr   <- getBackendAddress
+    (listenAddr, sendAddr) <- getBackendAddress
     socket <- WS.getWebSocket
     isOpen <- WS.isOpen socket
     let onConnectionClosed = fatal "Connection closed."
@@ -18,4 +18,4 @@ withActiveConnection action = do
         void $ WS.onOpen  socket $ action socket
         void $ WS.onClose socket $ const onConnectionClosed
         void $ WS.onError socket onConnectionClosed
-        void $ WS.connect socket addr
+        void $ WS.connect socket listenAddr sendAddr

--- a/luna-studio/node-editor/src/NodeEditor/Event/Source.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/Source.hs
@@ -10,8 +10,6 @@ module NodeEditor.Event.Source
 
 import           Common.Prelude                    hiding (on)
 
-import           GHCJS.Prim                        (fromJSString)
-
 import qualified Common.Batch.Connector.Connection as BatchConnection
 import qualified JS.Atom                           as Atom
 import qualified JS.Scene                          as Scene
@@ -40,9 +38,7 @@ webSocketHandler conn = AddHandler $ \h -> do
     void $ WebSocket.onOpen conn $
         h $ Connection Connection.Opened
     void $ WebSocket.onMessage conn $ \event -> do
-        payloadJS <- WebSocket.getData event
-        let payload = fromJSString payloadJS
-        -- liftIO $ putStrLn $ "payload len " <> show (length payload)
+        payload <- WebSocket.getData event
         let frame = BatchConnection.deserialize payload
         mapM_ (h . Connection . Connection.Message) $ frame ^. BatchConnection.messages
     void $ WebSocket.onClose conn $ \event -> do

--- a/luna-studio/text-editor/src/JS/Config.hs
+++ b/luna-studio/text-editor/src/JS/Config.hs
@@ -9,8 +9,11 @@ import           Common.Prelude
 
 
 
-foreign import javascript safe "config.backendAddress"
-    getBackendAddress' :: IO JSString
+foreign import javascript safe "config.backendAddress.listen"
+    js_getListenAddress :: IO JSString
 
-getBackendAddress :: IO String
-getBackendAddress  = convert <$> getBackendAddress'
+foreign import javascript safe "config.backendAddress.send"
+    js_getSendAddress :: IO JSString
+
+getBackendAddress :: IO (String, String)
+getBackendAddress  = convert .: (,) <$> js_getListenAddress <*> js_getSendAddress

--- a/luna-studio/text-editor/src/TextEditor/Event/Loader.hs
+++ b/luna-studio/text-editor/src/TextEditor/Event/Loader.hs
@@ -9,7 +9,7 @@ import           Common.Prelude
 
 withActiveConnection :: (WebSocket -> IO ()) -> IO ()
 withActiveConnection action = do
-    addr   <- getBackendAddress
+    (listenAddr, sendAddr) <- getBackendAddress
     socket <- WS.getWebSocket
     isOpen <- WS.isOpen socket
     let onConnectionClosed = putStrLn "ConnectionClosed."
@@ -19,4 +19,4 @@ withActiveConnection action = do
         void $ WS.onOpen socket $ action socket >> pushStatus (convert "Init") (convert "") (convert "")
         void $ WS.onClose socket $ const onConnectionClosed
         void $ WS.onError socket onConnectionClosed
-        void $ WS.connect socket addr
+        void $ WS.connect socket listenAddr sendAddr

--- a/luna-studio/text-editor/src/TextEditor/Event/Source.hs
+++ b/luna-studio/text-editor/src/TextEditor/Event/Source.hs
@@ -9,7 +9,8 @@ module TextEditor.Event.Source
 
 import           Common.Prelude                    hiding (on)
 
-import           GHCJS.Prim                        (fromJSString)
+import           GHCJS.Buffer                      as Buffer
+import           GHCJS.Buffer.Types                as Buffer
 
 import qualified Common.Batch.Connector.Connection as BatchConnection
 import qualified JS.Atom                           as Atom
@@ -35,9 +36,8 @@ webSocketHandler conn = AddHandler $ \h -> do
     void $ WebSocket.onOpen conn $
         h $ Connection Connection.Opened
     void $ WebSocket.onMessage conn $ \event -> do
-        payloadJS <- WebSocket.getData event
-        let payload = fromJSString payloadJS
-            frame = BatchConnection.deserialize payload
+        payload <- WebSocket.getData event
+        let frame = BatchConnection.deserialize payload
         mapM_ (h . Connection . Connection.Message) $ frame ^. BatchConnection.messages
     void $ WebSocket.onClose conn $ \event -> do
         code <- WebSocket.getCode event

--- a/tools/batch/plugins/ws-connector/package.yaml
+++ b/tools/batch/plugins/ws-connector/package.yaml
@@ -18,6 +18,7 @@ dependencies:
   - base
   - bytestring
   - either
+  - ekg
   - lib-ws-connector
   - m-logger
   - mtl

--- a/tools/batch/plugins/ws-connector/package.yaml
+++ b/tools/batch/plugins/ws-connector/package.yaml
@@ -7,6 +7,7 @@ maintainer:          contact@nodelab.io
 
 default-extensions:
   - NoImplicitPrelude
+  - OverloadedStrings
 
 executables:
   ws-connector:

--- a/tools/batch/plugins/ws-connector/src/Main.hs
+++ b/tools/batch/plugins/ws-connector/src/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import           GHC.IO.Encoding        (setLocaleEncoding, utf8)
@@ -13,6 +15,7 @@ import qualified ZMQ.Bus.Config          as Config
 import qualified ZMQ.Bus.EndPoint        as EndPoint
 import qualified ZMQ.Bus.WS.Config       as WSConfigLoader
 
+import System.Remote.Monitoring (forkServer)
 
 
 rootLogger :: Logger
@@ -29,6 +32,7 @@ opts = Opt.info (helper <*> parser)
 main :: IO ()
 main = do
     setLocaleEncoding utf8
+    -- forkServer "127.0.0.1" 12345
     execParser opts >>= run
 
 run :: Cmd -> IO ()

--- a/tools/batch/plugins/ws-connector/src/Main.hs
+++ b/tools/batch/plugins/ws-connector/src/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Main where
 
 import           GHC.IO.Encoding        (setLocaleEncoding, utf8)


### PR DESCRIPTION
Okay, soo... It turns out our websockets server sucked big time. At this point I'm not sure if that's only on macs or were linuxes affected too. For macs, any visualization result of ~1MB had a 50% chance of never making it to GUI and anything larger just never made it. Anyway, it now works better on both platforms (i.e. it actually started working on mac and is faster on linux). What happened in this PR:

1. I have reworked the sockets to use binary data instead of base64-encoding everything. Reduces encoding overhead and reduces package sizes by a factor of 2.
2. Swapped STM's TChans for Unagi chans. This fixed some memory leaks and, in particular a lot of busy spin-locking. Slap me if I ever want to use STM again.
3. This is what makes macOS distribution work. We are changing the implementation from a single, duplex websocket to two separate connections, one for each direction of GUI <-> backend communications. "Why", you may ask, "aren't websockets duplexed by default and should work just fine in this mode?". They should. But the HS `websockets` library has a rather serious bug that breaks duplex. We may switch back to a single socket once this issue is resolved: https://github.com/jaspervdj/websockets/issues/178.