### PR TITLE
JSString magic

### DIFF
--- a/libs/luna-studio-common/package.yaml
+++ b/libs/luna-studio-common/package.yaml
@@ -34,6 +34,10 @@ dependencies:
   - yaml
   - zlib
 
+when:
+  - condition: impl(ghcjs)
+    dependencies: [ghcjs-base]
+
 default-extensions:
     - AllowAmbiguousTypes
     - ApplicativeDo

--- a/libs/luna-studio-common/src/Data/Portable/Text.hs
+++ b/libs/luna-studio-common/src/Data/Portable/Text.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+#ifdef ghcjs_HOST_OS
+{-# LANGUAGE JavaScriptFFI #-}
+#endif
+
+module Data.Portable.Text where
+
+import Prologue
+
+#ifdef ghcjs_HOST_OS
+
+import           Data.JSString                     (JSString)
+import qualified Data.JSString                     as JSString
+import qualified Data.JSString.Text                as JSString
+import           JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
+import qualified GHCJS.Buffer                      as Buffer
+import           Data.ByteString                   (ByteString)
+import           Data.Binary                       (Binary, put, get)
+import           Data.Aeson.Types                  ( ToJSON
+                                                   , FromJSON
+                                                   , toJSON
+                                                   , parseJSON)
+
+#else
+
+import           Data.Text        (Text)
+
+#endif
+
+
+#ifdef ghcjs_HOST_OS
+
+type PortableText = JSString
+
+foreign import javascript unsafe "new TextDecoder(\"utf-8\").decode(new DataView($1, $2, $3))"
+    js_decodeUtf8 :: ArrayBuffer -> Int -> Int -> JSString
+
+foreign import javascript unsafe "new TextEncoder().encode($1)"
+    js_encodeUtf8 :: JSString -> ArrayBuffer
+
+encodeUtf8 :: JSString -> ByteString
+encodeUtf8 = Buffer.toByteString 0 Nothing
+           . Buffer.createFromArrayBuffer
+           . js_encodeUtf8
+
+decodeUtf8 :: ByteString -> JSString
+decodeUtf8 bs = js_decodeUtf8 arrBuf off len where
+    (buf, off, len) = Buffer.fromByteString bs
+    arrBuf = Buffer.getArrayBuffer buf
+
+instance Binary JSString where
+    put = put . encodeUtf8
+    get = decodeUtf8 <$> get
+
+instance ToJSON JSString where
+    toJSON   = toJSON . JSString.textFromJSString
+
+instance FromJSON JSString where
+    parseJSON = fmap JSString.textToJSString . parseJSON
+
+#else
+
+type PortableText = Text
+
+#endif

--- a/libs/luna-studio-common/src/Data/Portable/Text.hs
+++ b/libs/luna-studio-common/src/Data/Portable/Text.hs
@@ -32,7 +32,7 @@ import           Data.Text        (Text)
 
 type PortableText = JSString
 
-foreign import javascript unsafe "new TextDecoder(\"utf-8\").decode(new DataView($1, $2, $3))"
+foreign import javascript unsafe "new TextDecoder('utf-8').decode(new DataView($1, $2, $3))"
     js_decodeUtf8 :: ArrayBuffer -> Int -> Int -> JSString
 
 foreign import javascript unsafe "new TextEncoder().encode($1)"

--- a/libs/luna-studio-common/src/LunaStudio/Data/Visualization.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Visualization.hs
@@ -1,18 +1,17 @@
 module LunaStudio.Data.Visualization where
 
-import           Data.Aeson.Types (FromJSON, ToJSON)
-import           Data.Binary      (Binary)
-import           Data.Text        (Text)
-import           Data.UUID.Types  (UUID)
-import           Prologue         hiding (Text)
+import           Data.Aeson.Types   (FromJSON, ToJSON)
+import           Data.Binary        (Binary)
+import           Data.Portable.Text (PortableText)
+import           Data.UUID.Types    (UUID)
+import           Prologue           hiding (Text)
 
 
-type VisualizationData = [Text]
 type VisualizationId   = UUID
 data VisualizationValue
-    = Value Text
+    = Value PortableText
     | StreamStart
-    | StreamDataPoint Text
+    | StreamDataPoint PortableText
     deriving (Eq, Generic, Show)
 
 makePrisms ''VisualizationValue

--- a/luna-studio/lib/src/Common/Prelude/Instances.hs
+++ b/luna-studio/lib/src/Common/Prelude/Instances.hs
@@ -10,6 +10,7 @@ import           Data.HashMap.Strict          (HashMap)
 import qualified Data.HashMap.Strict          as HashMap
 import           Data.JSString                (JSString)
 import qualified Data.JSString                as JSString
+import qualified Data.JSString.Text           as JSString
 import           Development.Placeholders
 import           Prologue
 import           React.Flux
@@ -34,10 +35,10 @@ instance Default JSString where
     def = JSString.empty
 
 instance Convertible Text JSString where
-    convert = JSString.pack . convert
+    convert = JSString.textToJSString
 
 instance Convertible JSString Text where
-    convert = convert . JSString.unpack
+    convert = JSString.textFromJSString
 
 instance Convertible String JSString where
     convert = JSString.pack

--- a/luna-studio/lib/src/IdentityString.hs
+++ b/luna-studio/lib/src/IdentityString.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE JavaScriptFFI #-}
+
+module IdentityString where
+
+import Common.Prelude
+import Data.Text      (Text)
+import Unsafe.Coerce
+
+data IdentityString = IdentityString { _jsString :: !JSString
+                                     , _eqRef    :: !JSVal }
+
+makeLenses ''IdentityString
+
+foreign import javascript unsafe "$1===$2"
+    jsValEq :: JSVal -> JSVal -> Bool
+
+foreign import javascript safe "new Object()"
+    newRef :: IO JSVal
+
+instance Eq IdentityString where
+    IdentityString _ r1 == IdentityString _ r2 = jsValEq r1 r2
+
+fromJSString :: JSString -> IO IdentityString
+fromJSString t = IdentityString t <$> newRef

--- a/luna-studio/lib/src/IdentityString.hs
+++ b/luna-studio/lib/src/IdentityString.hs
@@ -6,8 +6,9 @@ import Common.Prelude
 import Data.Text      (Text)
 import Unsafe.Coerce
 
-data IdentityString = IdentityString { _jsString :: !JSString
-                                     , _eqRef    :: !JSVal }
+data IdentityString = IdentityString
+    { _jsString :: !JSString
+    , _eqRef    :: !JSVal }
 
 makeLenses ''IdentityString
 
@@ -20,5 +21,5 @@ foreign import javascript safe "new Object()"
 instance Eq IdentityString where
     IdentityString _ r1 == IdentityString _ r2 = jsValEq r1 r2
 
-fromJSString :: JSString -> IO IdentityString
-fromJSString t = IdentityString t <$> newRef
+fromJSString :: MonadIO m => JSString -> m IdentityString
+fromJSString t = liftIO $ IdentityString t <$> newRef

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/NodeEditor.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/NodeEditor.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DeriveAnyClass         #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase             #-}
 {-# LANGUAGE RankNTypes             #-}
@@ -11,6 +10,7 @@ import           Common.Prelude
 import qualified Data.HashMap.Strict                        as HashMap
 import           Data.Map                                   (Map)
 import qualified Data.Map                                   as Map
+import           IdentityString                             (IdentityString)
 import qualified LunaStudio.Data.Breadcrumb                 as B
 import           LunaStudio.Data.CameraTransformation       (CameraTransformation)
 import qualified LunaStudio.Data.Error                      as Error
@@ -68,12 +68,18 @@ data NodeEditor = NodeEditor { _expressionNodes          :: ExpressionNodesMap
 data VisualizersPaths    = VisualizersPaths { _internalVisualizersPath :: FilePath
                                             , _lunaVisualizersPath     :: FilePath
                                             , _projectVisualizersPath  :: Maybe FilePath
-                                            } deriving (Default, Eq, Generic)
+                                            } deriving (Eq, Generic)
+instance Default VisualizersPaths
 
-data VisualizationBackup     = ValueBackup Text | StreamBackup [Text] | MessageBackup Text | ErrorBackup Text deriving (Generic, Eq, Show)
+data VisualizationBackup = ValueBackup IdentityString
+                         | StreamBackup [IdentityString]
+                         | MessageBackup Text
+                         | ErrorBackup Text
+                         deriving (Eq)
 data VisualizationsBackupMap = VisualizationsBackupMap { _backupMap :: Map NodeLoc VisualizationBackup
-                                                       } deriving (Generic, Default)
+                                                       } deriving (Generic)
 instance Eq VisualizationsBackupMap where _ == _ = True
+instance Default VisualizationsBackupMap
 
 instance Default NodeEditor where
     def = NodeEditor

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/NodeEditor.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/NodeEditor.hs
@@ -71,11 +71,13 @@ data VisualizersPaths    = VisualizersPaths { _internalVisualizersPath :: FilePa
                                             } deriving (Eq, Generic)
 instance Default VisualizersPaths
 
-data VisualizationBackup = ValueBackup IdentityString
-                         | StreamBackup [IdentityString]
-                         | MessageBackup Text
-                         | ErrorBackup Text
-                         deriving (Eq)
+data VisualizationBackup
+    = ValueBackup IdentityString
+    | StreamBackup [IdentityString]
+    | MessageBackup Text
+    | ErrorBackup Text
+    deriving (Eq)
+
 data VisualizationsBackupMap = VisualizationsBackupMap { _backupMap :: Map NodeLoc VisualizationBackup
                                                        } deriving (Generic)
 instance Eq VisualizationsBackupMap where _ == _ = True

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 module NodeEditor.Action.Basic.UpdateNodeValue where
 
 import           Common.Action.Command                      (Command)
@@ -9,6 +10,7 @@ import qualified Data.Map                                   as Map
 import qualified Data.Text                                  as Text
 import qualified Data.Text.Lazy                             as Text.Lazy
 import qualified Data.Text.Lazy.Encoding                    as Text.Lazy
+import qualified IdentityString                             as IS
 import           LunaStudio.Data.Error                      (errorContent)
 import           LunaStudio.Data.NodeValue                  (NodeValue (NodeError, NodeValue))
 import           NodeEditor.Action.State.NodeEditor         (getExpressionNodeType, getVisualizersForType, modifyExpressionNode,
@@ -26,10 +28,12 @@ updateNodeValueAndVisualization :: NodeLoc -> NodeValue -> Command State ()
 updateNodeValueAndVisualization nl = \case
     NodeValue sv (Just (StreamDataPoint visVal)) -> do
         modifyExpressionNode nl $ value .= ShortValue (Text.take 100 sv)
-        setVisualizationData nl (StreamBackup [visVal]) False
+        !vis <- liftIO $ IS.fromJSString visVal
+        setVisualizationData nl (StreamBackup [vis]) False
     NodeValue sv (Just (Value visVal)) -> do
         modifyExpressionNode nl $ value .= ShortValue (Text.take 100 sv)
-        setVisualizationData nl (ValueBackup visVal) True
+        !vis <- liftIO $ IS.fromJSString visVal
+        setVisualizationData nl (ValueBackup vis) True
     NodeValue sv (Just StreamStart) -> do
         modifyExpressionNode nl $ value .= ShortValue (Text.take 100 sv)
         setVisualizationData nl (StreamBackup []) True

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNodeValue.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BangPatterns #-}
 module NodeEditor.Action.Basic.UpdateNodeValue where
 
 import           Common.Action.Command                      (Command)

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
@@ -68,7 +68,7 @@ updateDocs = withJustM getSearcher $ \s -> withJust (s ^. Searcher.docVis)
                 (docVis ^. visualizationId)
                 (ConstructorRep "Text" def)
                 =<< (IS.fromJSString . JSString.pack . BS.unpack
-                        $ Aeson.encode doc)
+                    $ Aeson.encode doc)
 
 localUpdateSearcherHintsPreservingSelection :: Command State ()
 localUpdateSearcherHintsPreservingSelection = do

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
@@ -5,11 +5,13 @@ import           Common.Action.Command                (Command)
 import           Common.Prelude
 import qualified Data.Aeson                           as Aeson
 import qualified Data.ByteString.Lazy.Char8           as BS
+import qualified Data.JSString                        as JSString
 import qualified Data.Map                             as Map
 import           Data.Set                             (Set)
 import qualified Data.Set                             as Set
 import           Data.Text                            (Text)
 import qualified Data.Text                            as Text
+import qualified IdentityString                       as IS
 import           JS.Visualizers                       (sendVisualizationData)
 import           LunaStudio.Data.NodeSearcher         (EntryType (Function), ImportName, ImportsHints, Match (Match),
                                                        ModuleHints (ModuleHints), RawEntry (RawEntry), TypePreferation (TypePreferation),
@@ -65,7 +67,8 @@ updateDocs = withJustM getSearcher $ \s -> withJust (s ^. Searcher.docVis)
             sendVisualizationData
                 (docVis ^. visualizationId)
                 (ConstructorRep "Text" def)
-                (Text.pack . BS.unpack $ Aeson.encode doc)
+                =<< (IS.fromJSString . JSString.pack . BS.unpack
+                        $ Aeson.encode doc)
 
 localUpdateSearcherHintsPreservingSelection :: Command State ()
 localUpdateSearcherHintsPreservingSelection = do


### PR DESCRIPTION
OK, what happened here?

1. Fixing the `convert` instance between `JSString` and `Text`. This alone is enough to fix most of our problems.
2. Introducing `PortableText` inside luna-studio-common. It's a type that is a `Text` in GHC and `JSString` in GHCJS, with binary–compatible representations. It is currently only used for visualization data (which in turn renders the fix from 1. unnecessary, though still a speed up for other parts of the GUI). Optimally, we should switch GUI to use only JSStrings and the whole API to this PortableText thingy – this avoids conversions altogether and `JSString` is the most performant text representation available in GHCJS. Also, yes, the Aeson instances are bad (converting via Text), but GHCJS's JSON handling is broken (`Map` is not a supported type), so we should probably fix that too as a separate effort.
3. Introducing `IdentityString` – a wrapper for JSString with reference-based equality semantics. Used only for one comparison performed by GUI when handling visualization data. It's kind of ugly and it would be best not to do this comparison at all – this is for @ljkania to decide how to best handle this. Also, the name comes from Java's `IdentityHashMap` and friends, which have same semantics. If you have a better idea for a name, I'm open to changing.