### PR TITLE
Make focusing visualization possible #900

### DIFF
--- a/luna-studio/atom/lib/luna-node-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-node-editor-tab.coffee
@@ -75,6 +75,9 @@ class LunaNodeEditorTab extends View
                     tag:      evt.tag.substring(0, evt.tag.length - 5)
                     contents: evt
 
+                unless target?
+                    target = []
+
                 @nodeEditor.pushViewEvent
                     path:   path
                     target: target

--- a/luna-studio/atom/lib/luna-node-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-node-editor-tab.coffee
@@ -75,8 +75,7 @@ class LunaNodeEditorTab extends View
                     tag:      evt.tag.substring(0, evt.tag.length - 5)
                     contents: evt
 
-                unless target?
-                    target = []
+                target ?= []
 
                 @nodeEditor.pushViewEvent
                     path:   path

--- a/luna-studio/node-editor/src/NodeEditor/Event/View.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/View.hs
@@ -114,16 +114,24 @@ data FocusVisualizationEvent = FocusVisualizationEvent
 
 makeLenses ''FocusVisualizationEvent
 
+data ToggleVisualizationsEvent = ToggleVisualizationsEvent
+    { _aesonTooOld8 :: Maybe ()
+    , _aesonTooOld9 :: Maybe ()
+    } deriving (Generic, Show)
+
+makeLenses ''ToggleVisualizationsEvent
+
 data BaseEvent
-    = Mouse              MouseEvent
-    | Navigate           NavigateEvent
-    | NodeMove           NodeMoveEvent
-    | NodeSelect         NodeSelectEvent
-    | Disconnect         DisconnectEvent
-    | SearcherAccept     SearcherAcceptEvent
-    | SearcherEdit       SearcherEditEvent
-    | SelectVisualizer   SelectVisualizerEvent
-    | FocusVisualization FocusVisualizationEvent
+    = Mouse                MouseEvent
+    | Navigate             NavigateEvent
+    | NodeMove             NodeMoveEvent
+    | NodeSelect           NodeSelectEvent
+    | Disconnect           DisconnectEvent
+    | SearcherAccept       SearcherAcceptEvent
+    | SearcherEdit         SearcherEditEvent
+    | SelectVisualizer     SelectVisualizerEvent
+    | FocusVisualization   FocusVisualizationEvent
+    | ToggleVisualizations ToggleVisualizationsEvent
     deriving (Generic, Show)
 
 makePrisms ''BaseEvent
@@ -145,36 +153,39 @@ instance NFData SearcherAcceptEvent
 instance NFData SearcherEditEvent
 instance NFData SelectVisualizerEvent
 instance NFData FocusVisualizationEvent
+instance NFData ToggleVisualizationsEvent
 instance NFData Target
 instance NFData ViewEvent
 instance NFData BaseEvent
 
-instance FromJSON MouseEvent              where parseJSON = parseDropUnary
-instance FromJSON NavigateEvent           where parseJSON = parseDropUnary
-instance FromJSON NodeMoveEvent           where parseJSON = parseDropUnary
-instance FromJSON NodeSelectEvent         where parseJSON = parseDropUnary
-instance FromJSON DisconnectEvent         where parseJSON = parseDropUnary
-instance FromJSON SearcherAcceptEvent     where parseJSON = parseDropUnary
-instance FromJSON SearcherEditEvent       where parseJSON = parseDropUnary
-instance FromJSON SelectVisualizerEvent   where parseJSON = parseDropUnary
-instance FromJSON FocusVisualizationEvent where parseJSON = parseDropUnary
-instance FromJSON Target                  where parseJSON = parseDropUnary
-instance FromJSON ViewEvent               where parseJSON = parseDropUnary
-instance FromJSON BaseEvent               where parseJSON = parseDropUnary
+instance FromJSON MouseEvent                where parseJSON = parseDropUnary
+instance FromJSON NavigateEvent             where parseJSON = parseDropUnary
+instance FromJSON NodeMoveEvent             where parseJSON = parseDropUnary
+instance FromJSON NodeSelectEvent           where parseJSON = parseDropUnary
+instance FromJSON DisconnectEvent           where parseJSON = parseDropUnary
+instance FromJSON SearcherAcceptEvent       where parseJSON = parseDropUnary
+instance FromJSON SearcherEditEvent         where parseJSON = parseDropUnary
+instance FromJSON SelectVisualizerEvent     where parseJSON = parseDropUnary
+instance FromJSON FocusVisualizationEvent   where parseJSON = parseDropUnary
+instance FromJSON ToggleVisualizationsEvent where parseJSON = parseDropUnary
+instance FromJSON Target                    where parseJSON = parseDropUnary
+instance FromJSON ViewEvent                 where parseJSON = parseDropUnary
+instance FromJSON BaseEvent                 where parseJSON = parseDropUnary
 
 
-instance ToJSON MouseEvent              where toEncoding = toEncodingDropUnary
-instance ToJSON NavigateEvent           where toEncoding = toEncodingDropUnary
-instance ToJSON NodeMoveEvent           where toEncoding = toEncodingDropUnary
-instance ToJSON NodeSelectEvent         where toEncoding = toEncodingDropUnary
-instance ToJSON DisconnectEvent         where toEncoding = toEncodingDropUnary
-instance ToJSON SearcherAcceptEvent     where toEncoding = toEncodingDropUnary
-instance ToJSON SearcherEditEvent       where toEncoding = toEncodingDropUnary
-instance ToJSON SelectVisualizerEvent   where toEncoding = toEncodingDropUnary
-instance ToJSON FocusVisualizationEvent where toEncoding = toEncodingDropUnary
-instance ToJSON Target                  where toEncoding = toEncodingDropUnary
-instance ToJSON ViewEvent               where toEncoding = toEncodingDropUnary
-instance ToJSON BaseEvent               where toEncoding = toEncodingDropUnary
+instance ToJSON MouseEvent                where toEncoding = toEncodingDropUnary
+instance ToJSON NavigateEvent             where toEncoding = toEncodingDropUnary
+instance ToJSON NodeMoveEvent             where toEncoding = toEncodingDropUnary
+instance ToJSON NodeSelectEvent           where toEncoding = toEncodingDropUnary
+instance ToJSON DisconnectEvent           where toEncoding = toEncodingDropUnary
+instance ToJSON SearcherAcceptEvent       where toEncoding = toEncodingDropUnary
+instance ToJSON SearcherEditEvent         where toEncoding = toEncodingDropUnary
+instance ToJSON SelectVisualizerEvent     where toEncoding = toEncodingDropUnary
+instance ToJSON FocusVisualizationEvent   where toEncoding = toEncodingDropUnary
+instance ToJSON ToggleVisualizationsEvent where toEncoding = toEncodingDropUnary
+instance ToJSON Target                    where toEncoding = toEncodingDropUnary
+instance ToJSON ViewEvent                 where toEncoding = toEncodingDropUnary
+instance ToJSON BaseEvent                 where toEncoding = toEncodingDropUnary
 
 instance EventName ViewEvent where
     eventName = intercalate "." . view path

--- a/luna-studio/node-editor/src/NodeEditor/Event/View.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/View.hs
@@ -9,6 +9,7 @@ import           Data.Convert                       (Convertible (convert))
 import           LunaStudio.Data.NodeLoc            (NodeLoc)
 import           LunaStudio.Data.PortRef            (InPortRef (InPortRef), OutPortRef (OutPortRef))
 import           LunaStudio.Data.ScreenPosition     (ScreenPosition, fromDoubles)
+import           LunaStudio.Data.Visualization      (VisualizationId)
 import           LunaStudio.Data.Visualizer         (VisualizerId (VisualizerId))
 import           NodeEditor.React.Model.Breadcrumbs (Breadcrumb, BreadcrumbItem)
 import           Prelude                            (error)
@@ -57,28 +58,28 @@ makeLenses ''MouseEvent
 
 data NavigateEvent = NavigateEvent
     { _to :: Breadcrumb BreadcrumbItem
-    , _aesonToOld1 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
+    , _aesonTooOld1 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
     } deriving (Generic, Show)
 
 makeLenses ''NavigateEvent
 
 data NodeMoveEvent = NodeMoveEvent
     { _position :: (Double, Double)
-    , _aesonToOld2 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
+    , _aesonTooOld2 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
     } deriving (Generic, Show)
 
 makeLenses ''NodeMoveEvent
 
 data NodeSelectEvent = NodeSelectEvent
     { _select :: Bool
-    , _aesonToOld3 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
+    , _aesonTooOld3 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
     } deriving (Generic, Show)
 
 makeLenses ''NodeSelectEvent
 
 data DisconnectEvent = DisconnectEvent
     { _src :: Bool
-    , _aesonToOld4 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
+    , _aesonTooOld4 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
     } deriving (Generic, Show)
 
 makeLenses ''DisconnectEvent
@@ -101,20 +102,28 @@ makeLenses ''SearcherEditEvent
 
 data SelectVisualizerEvent = SelectVisualizerEvent
     { _visualizerId :: VisualizerId
-    , _aesonToOld5 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
+    , _aesonTooOld5 :: Maybe () --FIXME: replace with tagSingleConstructors when Aeson bumped
     } deriving (Generic, Show)
 
 makeLenses ''SelectVisualizerEvent
 
+data FocusVisualizationEvent = FocusVisualizationEvent
+    { _aesonTooOld6 :: Maybe ()
+    , _aesonTooOld7 :: Maybe ()
+    } deriving (Generic, Show)
+
+makeLenses ''FocusVisualizationEvent
+
 data BaseEvent
-    = Mouse            MouseEvent
-    | Navigate         NavigateEvent
-    | NodeMove         NodeMoveEvent
-    | NodeSelect       NodeSelectEvent
-    | Disconnect       DisconnectEvent
-    | SearcherAccept   SearcherAcceptEvent
-    | SearcherEdit     SearcherEditEvent
-    | SelectVisualizer SelectVisualizerEvent
+    = Mouse              MouseEvent
+    | Navigate           NavigateEvent
+    | NodeMove           NodeMoveEvent
+    | NodeSelect         NodeSelectEvent
+    | Disconnect         DisconnectEvent
+    | SearcherAccept     SearcherAcceptEvent
+    | SearcherEdit       SearcherEditEvent
+    | SelectVisualizer   SelectVisualizerEvent
+    | FocusVisualization FocusVisualizationEvent
     deriving (Generic, Show)
 
 makePrisms ''BaseEvent
@@ -135,34 +144,37 @@ instance NFData DisconnectEvent
 instance NFData SearcherAcceptEvent
 instance NFData SearcherEditEvent
 instance NFData SelectVisualizerEvent
+instance NFData FocusVisualizationEvent
 instance NFData Target
 instance NFData ViewEvent
 instance NFData BaseEvent
 
-instance FromJSON MouseEvent            where parseJSON = parseDropUnary
-instance FromJSON NavigateEvent         where parseJSON = parseDropUnary
-instance FromJSON NodeMoveEvent         where parseJSON = parseDropUnary
-instance FromJSON NodeSelectEvent       where parseJSON = parseDropUnary
-instance FromJSON DisconnectEvent       where parseJSON = parseDropUnary
-instance FromJSON SearcherAcceptEvent   where parseJSON = parseDropUnary
-instance FromJSON SearcherEditEvent     where parseJSON = parseDropUnary
-instance FromJSON SelectVisualizerEvent where parseJSON = parseDropUnary
-instance FromJSON Target                where parseJSON = parseDropUnary
-instance FromJSON ViewEvent             where parseJSON = parseDropUnary
-instance FromJSON BaseEvent             where parseJSON = parseDropUnary
+instance FromJSON MouseEvent              where parseJSON = parseDropUnary
+instance FromJSON NavigateEvent           where parseJSON = parseDropUnary
+instance FromJSON NodeMoveEvent           where parseJSON = parseDropUnary
+instance FromJSON NodeSelectEvent         where parseJSON = parseDropUnary
+instance FromJSON DisconnectEvent         where parseJSON = parseDropUnary
+instance FromJSON SearcherAcceptEvent     where parseJSON = parseDropUnary
+instance FromJSON SearcherEditEvent       where parseJSON = parseDropUnary
+instance FromJSON SelectVisualizerEvent   where parseJSON = parseDropUnary
+instance FromJSON FocusVisualizationEvent where parseJSON = parseDropUnary
+instance FromJSON Target                  where parseJSON = parseDropUnary
+instance FromJSON ViewEvent               where parseJSON = parseDropUnary
+instance FromJSON BaseEvent               where parseJSON = parseDropUnary
 
 
-instance ToJSON MouseEvent            where toEncoding = toEncodingDropUnary
-instance ToJSON NavigateEvent         where toEncoding = toEncodingDropUnary
-instance ToJSON NodeMoveEvent         where toEncoding = toEncodingDropUnary
-instance ToJSON NodeSelectEvent       where toEncoding = toEncodingDropUnary
-instance ToJSON DisconnectEvent       where toEncoding = toEncodingDropUnary
-instance ToJSON SearcherAcceptEvent   where toEncoding = toEncodingDropUnary
-instance ToJSON SearcherEditEvent     where toEncoding = toEncodingDropUnary
-instance ToJSON SelectVisualizerEvent where toEncoding = toEncodingDropUnary
-instance ToJSON Target                where toEncoding = toEncodingDropUnary
-instance ToJSON ViewEvent             where toEncoding = toEncodingDropUnary
-instance ToJSON BaseEvent             where toEncoding = toEncodingDropUnary
+instance ToJSON MouseEvent              where toEncoding = toEncodingDropUnary
+instance ToJSON NavigateEvent           where toEncoding = toEncodingDropUnary
+instance ToJSON NodeMoveEvent           where toEncoding = toEncodingDropUnary
+instance ToJSON NodeSelectEvent         where toEncoding = toEncodingDropUnary
+instance ToJSON DisconnectEvent         where toEncoding = toEncodingDropUnary
+instance ToJSON SearcherAcceptEvent     where toEncoding = toEncodingDropUnary
+instance ToJSON SearcherEditEvent       where toEncoding = toEncodingDropUnary
+instance ToJSON SelectVisualizerEvent   where toEncoding = toEncodingDropUnary
+instance ToJSON FocusVisualizationEvent where toEncoding = toEncodingDropUnary
+instance ToJSON Target                  where toEncoding = toEncodingDropUnary
+instance ToJSON ViewEvent               where toEncoding = toEncodingDropUnary
+instance ToJSON BaseEvent               where toEncoding = toEncodingDropUnary
 
 instance EventName ViewEvent where
     eventName = intercalate "." . view path
@@ -274,3 +286,7 @@ instance Convertible Target NodeLoc where
 instance Convertible Target VisualizerId where
     convert (Target [visId]) = read visId
     convert _ = error "Cannot parse Target to VisualizerId"
+
+instance Convertible Target VisualizationId where
+    convert (Target [visId]) = read visId
+    convert _ = error "Cannot parse Target to VisualizationId"

--- a/luna-studio/node-editor/src/NodeEditor/Handler/Visualization.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Visualization.hs
@@ -9,7 +9,7 @@ import           NodeEditor.Event.Event               (Event (View))
 import           NodeEditor.Event.Shortcut            (ShortcutEvent)
 import qualified NodeEditor.Event.Shortcut            as Shortcut
 import           NodeEditor.Event.UI                  (UIEvent (AppEvent, VisualizationEvent))
-import           NodeEditor.Event.View                (BaseEvent (SelectVisualizer), ViewEvent (ViewEvent), base, path, _FocusVisualization, _SelectVisualizer)
+import           NodeEditor.Event.View                (BaseEvent (SelectVisualizer), ViewEvent (ViewEvent), base, path, _FocusVisualization, _SelectVisualizer, _ToggleVisualizations)
 import qualified NodeEditor.Event.View                as View
 import qualified NodeEditor.React.Event.App           as App
 import qualified NodeEditor.React.Event.Visualization as Visualization
@@ -63,9 +63,12 @@ handleViewEvent evt = case evt ^. path of
                 then Just $ Visualization.focusVisualization parent visId
                 else Nothing
         listToMaybe $ catMaybes [mayFocus, maySelect]
-    _ -> if unfocusesVisualization evt
-        then Just exitAnyVisualizationMode
-        else Nothing
+    _ -> if has (base . _ToggleVisualizations) evt
+            then Just . Visualization.toggleVisualizations
+                . Node . convert $ evt ^. View.target
+        else if unfocusesVisualization evt
+            then Just exitAnyVisualizationMode
+            else Nothing
 
 exitAnyVisualizationMode :: Command State ()
 exitAnyVisualizationMode = do

--- a/luna-studio/node-editor/src/NodeEditor/Handler/Visualization.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Visualization.hs
@@ -9,7 +9,7 @@ import           NodeEditor.Event.Event               (Event (View))
 import           NodeEditor.Event.Shortcut            (ShortcutEvent)
 import qualified NodeEditor.Event.Shortcut            as Shortcut
 import           NodeEditor.Event.UI                  (UIEvent (AppEvent, VisualizationEvent))
-import           NodeEditor.Event.View                (BaseEvent (SelectVisualizer), ViewEvent (ViewEvent), base, path, _SelectVisualizer)
+import           NodeEditor.Event.View                (BaseEvent (SelectVisualizer), ViewEvent (ViewEvent), base, path, _FocusVisualization, _SelectVisualizer)
 import qualified NodeEditor.Event.View                as View
 import qualified NodeEditor.React.Event.App           as App
 import qualified NodeEditor.React.Event.Visualization as Visualization
@@ -45,18 +45,27 @@ handleShortcutEvent evt = case evt ^. Shortcut.shortcut of
     Shortcut.CloseVisualizationPreview  -> Just exitAnyVisualizationMode
     _ -> Nothing
 
+unfocusesVisualization :: ViewEvent -> Bool
+unfocusesVisualization evt = case evt ^. base of
+    View.FocusVisualization {} -> False
+    View.Mouse mevt            -> not $ elem (mevt ^. View.type_)
+        ["mouseenter", "mouseleave", "mousemove", "mouseout", "mouseover"]
+    _                          -> True
+
 handleViewEvent :: ViewEvent -> Maybe (Command State ())
-handleViewEvent evt = if not $ has (base . _SelectVisualizer) evt
-    then Nothing
-    else case evt ^. path of
-        [ "NodeEditor"
-            , "NodeVisualizations", nlString
-            , "Visualization",      visIdString ]
-            -> Visualization.selectVisualizer
-                (Node $ read nlString)
-                (read visIdString)
+handleViewEvent evt = case evt ^. path of
+    [ "NodeEditor", "NodeVisualization", nlString, visIdString ] -> do
+        let parent    = Node $ read nlString
+            visId     = read visIdString
+            maySelect = Visualization.selectVisualizer parent visId 
                 <$> evt ^? base . _SelectVisualizer . View.visualizerId
-        _ -> Nothing
+            mayFocus  = if has (base . _FocusVisualization) evt
+                then Just $ Visualization.focusVisualization parent visId
+                else Nothing
+        listToMaybe $ catMaybes [mayFocus, maySelect]
+    _ -> if unfocusesVisualization evt
+        then Just exitAnyVisualizationMode
+        else Nothing
 
 exitAnyVisualizationMode :: Command State ()
 exitAnyVisualizationMode = do


### PR DESCRIPTION
Please see: https://github.com/luna/basegl-ui/pull/4

This pr introduces the correct implementation of visualization logic. Elements are created only when necessary and updates are kept to the minimum. However there is a few issues we need to handle:
- There is some styling needed (visualization toggler is simple square, menu does not work well because of some problems with hover, background is transparent but should have color of background)
- We need to implement additional modes which show visualization full screen. To do that we need to add another layer first - this one will not be scaled and will be also used by searcher.
- We need to replace iframes with shadow dom since now focusing requires to rerender iframe loosing its state.

Awesome things this introduces:
- Extra layer for dom elements on top of base 3 layers of basegl. This one is for dom elements that should be in front (like focused visualization) and should be scaled. This layer does not affect any mouse events for base mechanism unless there is an element in this layer under the mouse.
- Two base modes for visualization: default and focused. The first one makes visualization non-responding to events and covered with basegl shape (visualization is in `layer-dom` from basegl at this state). After click on that shape visualization is focused - it is moved to top layer and events are enabled. Now everything should be under this visualization. Any outside action (but `mouseenter`, `mouseleave`, etc.) make visualization unfocus.
- Toggling node value between short value or error and visualization.