### PR TITLE
Use fs-no-eperm-anymore to rename files after downloading

### DIFF
--- a/luna-studio/atom/lib/projects.coffee
+++ b/luna-studio/atom/lib/projects.coffee
@@ -1,5 +1,7 @@
 fse     = require 'fs-extra'
 fs      = require 'fs-plus'
+fsNoEPERMMod = require 'fs-no-eperm-anymore'
+fsNoEPERM = fsNoEPERMMod.instantiate()
 path    = require 'path'
 request = require 'request'
 yaml    = require 'js-yaml'
@@ -122,11 +124,12 @@ tutorialOpen = (tutorial, progress, finalize) ->
                                 cloneError 'Wrong tutorial archive structure'
                             else
                                 srcPath = path.join unpackPath, files[0]
-                                fs.rename srcPath, dstPath, (err) =>
-                                    if err?
+                                fsNoEPERM.rename srcPath, dstPath
+                                    .then =>
+                                        atom.project.setPaths [dstPath]
+                                        finalize()
+                                    .catch (err) =>
                                         cloneError 'Cannot open tutorial: ' + err.message
-                                    atom.project.setPaths [dstPath]
-                                    finalize()
 
 ## RECENT PROJECTS ##
 

--- a/luna-studio/atom/package.json
+++ b/luna-studio/atom/package.json
@@ -11,7 +11,7 @@
     "consumedServices": {
         "status-bar": {
             "versions": {
-            "^1.0.0": "consumeStatusBar"
+                "^1.0.0": "consumeStatusBar"
             }
         }
     },
@@ -23,17 +23,18 @@
         "etch": "0.12.x",
         "first-mate": "7.0.x",
         "fs-extra": "5.0.x",
+        "fs-no-eperm-anymore": "^2.0.2",
         "fuzzaldrin": "^2.1.0",
         "jquery": "3.2.x",
         "js-yaml": "3.9.x",
         "luna-logo": "1.1.3",
         "mixpanel-browser": "2.9.x",
         "pako": "1.0.x",
-        "react-dom": "15.6.x",
         "react": "15.6.x",
-        "resize-observer-polyfill": "1.3.x",
+        "react-dom": "15.6.x",
         "request": "2.83.x",
         "request-progress": "3.0.x",
+        "resize-observer-polyfill": "1.3.x",
         "showdown": "1.8.x",
         "sub-atom": "1.0.x",
         "underscore": "1.8.x",


### PR DESCRIPTION
Should get rid of EPERM errors while downloading tutorials on Windows