### PR TITLE
Update luna commit hash.

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -58,7 +58,7 @@ packages:
 - {location: ../../tools/batch/plugins/luna-empire}
 - {location: ../../tools/batch/plugins/request-monitor}
 - extra-dep: true
-  location: {commit: 7e29ec5da1d6514f0565dbf491aea0051cbecdf2, git: 'git@github.com:luna/luna-core.git'}
+  location: {commit: 7603839e02b382dc50dcd713c743397382184635, git: 'git@github.com:luna/luna.git'}
   subdirs:
     - core
     - syntax/text/parser


### PR DESCRIPTION
Now that `luna-core` is defunct, this should point back to the main luna repo. 