### PR TITLE
Prevent naming defs as expressions #1031

### DIFF
--- a/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
+++ b/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
@@ -59,8 +59,11 @@ childrenFromSeq tgtBeg edge = do
             let uid    = fromMaybe newNodeId nodeId
             childTarget <- matchExpr expr' $ \case
                 Unify l r -> do
-                    ASTBuilder.attachNodeMarkers uid []      =<< source l
+                    ASTBuilder.attachNodeMarkers uid [] =<< source l
                     source r
+                ASGFunction n _ b -> do
+                    ASTBuilder.attachNodeMarkers uid [] =<< source n
+                    return expr'
                 _ -> do
                     putLayer @Marker expr' . Just =<< toPortMarker (OutPortRef (convert uid) [])
                     return expr'


### PR DESCRIPTION
There were still some issues where `def foo args...: returns...` node was connected to the output port or it got autoconnected after adding a node to the right. In these cases, it will be named to `expr1 = def foo...` breaking its uses in code. This pull request prevents that and ensures that connection of defs to output port is visible.