### PR TITLE
Clean redo stack on new action #1044

### DIFF
--- a/libs/undo-redo/package.yaml
+++ b/libs/undo-redo/package.yaml
@@ -15,6 +15,7 @@ dependencies:
   - lens
   - luna-studio-common
   - mtl
+  - m-logger
   - prologue
   - safe-exceptions
   - stm

--- a/libs/undo-redo/src/Handlers.hs
+++ b/libs/undo-redo/src/Handlers.hs
@@ -48,7 +48,13 @@ import qualified LunaStudio.Data.Graph                   as Graph
 import qualified LunaStudio.Data.Node                    as Node
 import           LunaStudio.Data.Port                    (OutPortIndex (Projection))
 import           LunaStudio.Data.PortRef                 (AnyPortRef (InPortRef'), OutPortRef (..))
+import qualified System.Log.MLogger                      as Logger
 import           Prologue                                hiding (throwM)
+
+
+logger :: Logger.Logger
+logger = Logger.getLogger $(Logger.moduleName)
+
 
 type Handler = ByteString -> UndoPure ()
 
@@ -156,7 +162,7 @@ compareMsgByUserId msg1 msg2 = case msg1 of
 handle :: UndoMessage -> UndoPure ()
 handle message = do
     undo    %= (message :)
-    redo    %= List.deleteBy compareMsgByUserId message
+    redo    %= List.filter (not . compareMsgByUserId message)
     history %= (message :)
 
 

--- a/libs/undo-redo/src/Undo.hs
+++ b/libs/undo-redo/src/Undo.hs
@@ -24,6 +24,7 @@ import qualified LunaStudio.API.Request    as Request
 import           LunaStudio.API.Topic      (Topic)
 import           Prologue                  hiding (null, throwM)
 import           UndoState
+import qualified System.Log.MLogger        as Logger
 import qualified ZMQ.Bus.Bus               as Bus
 import qualified ZMQ.Bus.Data.Flag         as Flag
 import qualified ZMQ.Bus.Data.Message      as Message
@@ -34,6 +35,10 @@ import qualified ZMQ.Bus.Trans             as Bus
 
 import qualified System.IO as IO
 
+
+
+logger :: Logger.Logger
+logger = Logger.getLogger $(Logger.moduleName)
 
 topic :: Topic
 topic = "empire."
@@ -107,7 +112,7 @@ doUndo guiID = do
     forM maybeMsg $ \msg -> do
         redo %= (msg :)
         undo %= List.delete msg
-        history %= (msg :) --FIXME odwróć kolejność wiadomości undo-redo?
+        history %= (msg :) --FIXME reverse the order of undo-redo messages?
         return $ act ActUndo msg
 
 doRedo :: MonadState UndoState m => UUID -> m (Maybe Action)


### PR DESCRIPTION
### Pull Request Description

With previous implementation, some stale actions could end up in redo stack longer than expected. When using redo afterwards, these action were executed in a state when they could no longer make sense. To prevent that, whenever a new action is performed by a user, redo stack is cleaned for that user.
