### PR TITLE
Initial searcher improvement

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -83,4 +83,4 @@ packages:
 - extra-dep: true
   location: {commit: ddfcd1e0372b93e947b380b911c123fe67227b21, git: 'git@github.com:luna/visualization-api.git'}
 - extra-dep: true
-  location: {commit: 8babf4c65507fa7608e6c6468be4fcabddf77327, git: 'git@github.com:luna/fuzzy-text.git'}
+  location: {commit: 1fe94d4d8b106b2ab37c65de9200b3f0404ac2ca, git: 'git@github.com:luna/fuzzy-text.git'}

--- a/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
@@ -6,8 +6,7 @@ import           Control.Concurrent                      (forkIO)
 import           Control.Concurrent.MVar                 (readMVar)
 import           Control.Concurrent.STM.TChan            (writeTChan)
 import           Control.Error                           (runExceptT)
-import           Control.Lens                            ((.=), (^..), to,
-                                                          traversed, use)
+import           Control.Lens                            (to, traversed, use, (.=), (^..))
 import           Control.Monad                           (when)
 import           Control.Monad.Catch                     (handle, try)
 import           Control.Monad.Reader                    (asks)
@@ -46,7 +45,7 @@ import qualified Empire.Env                              as Env
 import           Empire.Server.Server                    (defInverse, errorMessage, modifyGraph, modifyGraphOk, prettyException, replyFail,
                                                           replyOk, replyResult, sendToBus', webGUIHack, withDefaultResult,
                                                           withDefaultResultTC)
-import           Luna.Package                            (findPackageFileForFile, getRelativePathForModule, findPackageRootForFile)
+import           Luna.Package                            (findPackageFileForFile, findPackageRootForFile, getRelativePathForModule)
 import qualified LunaStudio.API.Atom.GetBuffer           as GetBuffer
 import qualified LunaStudio.API.Atom.Substitute          as Substitute
 import qualified LunaStudio.API.Control.Interpreter      as Interpreter
@@ -415,7 +414,7 @@ handleRemoveNodes :: Request RemoveNodes.Request -> StateT Env BusT ()
 handleRemoveNodes = modifyGraph inverse action replyResult where
     inverse (RemoveNodes.Request location nodeLocs) = do
         let nodeIds = convert <$> nodeLocs --TODO[PM -> MM] Use NodeLoc instead of NodeId
-        Graph allNodes allConnections _ _ monads <- Graph.getGraph location
+        Graph allNodes allConnections _ _ monads _ <- Graph.getGraph location
         let isNodeRelevant n = Set.member (n ^. Node.nodeId) idSet
             isConnRelevant c
                 =  Set.member (c ^. Connection.src . PortRef.srcNodeId) idSet

--- a/libs/batch/plugins/luna-empire/src/Empire/Server/Server.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server/Server.hs
@@ -155,14 +155,11 @@ catchAllExceptions act = try act
 withDefaultResult' :: (GraphLocation -> Empire Graph) -> GraphLocation
     -> Empire a -> Empire Diff
 withDefaultResult' getFinalGraph location action = do
-    let addImports imps g = g & GraphAPI.imports .~ imps
-    oldImports <- Graph.getAvailableImports location
-    oldGraph   <- (_Left %~ Graph.prepareGraphError) <$> catchAllExceptions
-        (addImports oldImports <$> Graph.getGraphNoTC location)
+    oldGraph <- (_Left %~ Graph.prepareGraphError)
+        <$> catchAllExceptions (Graph.getGraphNoTC location)
     void action
-    newImports <- Graph.getAvailableImports location
-    newGraph   <- (_Left %~ Graph.prepareGraphError) <$> catchAllExceptions
-        (addImports newImports <$> getFinalGraph location)
+    newGraph <- (_Left %~ Graph.prepareGraphError)
+        <$> catchAllExceptions (getFinalGraph location)
     pure $ diff oldGraph newGraph
 
 withDefaultResult :: GraphLocation -> Empire a -> Empire Diff

--- a/libs/luna-empire/src/Empire/Commands/Graph.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph.hs
@@ -1695,7 +1695,7 @@ getImportsInFile = matchUnit =<< use Graph.clsClass where
     matchImport imp = matchExpr imp $ \(Import absolute _) -> 
         matchAbsolute =<< source absolute
     matchAbsolute a = matchExpr a $ \(ImportSrc (Term.Absolute n)) -> 
-        pure . convert . nameToString $ convert n
+        pure . nameToText $ convert n
 
 getAvailableImports :: GraphLocation -> Empire (Set ImportName)
 getAvailableImports gl = withUnit pureGl mkImports where

--- a/libs/luna-empire/src/Empire/Commands/Graph.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph.hs
@@ -93,6 +93,7 @@ import           LunaStudio.Data.Connection       (Connection (..), ConnectionId
 import qualified LunaStudio.Data.Error            as ErrorAPI
 import qualified LunaStudio.Data.Graph            as APIGraph
 import           LunaStudio.Data.GraphLocation    (GraphLocation (..))
+import qualified LunaStudio.Data.GraphLocation    as GraphLocation
 import           LunaStudio.Data.Node             (ExpressionNode (..), NodeId)
 import qualified LunaStudio.Data.Node             as Node
 import           LunaStudio.Data.NodeCache        (NodeCache (..), nodeMetaMap, nodeIdMap)
@@ -1686,37 +1687,29 @@ nativeModuleName :: Text
 nativeModuleName = "Native"
 
 getImportsInFile :: ClassOp [Text]
-getImportsInFile = do
-    unit <- use Graph.clsClass
-    matchExpr unit $ \case
-        Unit imps _ _ -> do
-            imps' <- source imps
-            matchExpr imps' $ \case
-                ImportHub imps'' -> do
-                    imps <- ptrListToList imps''
-                    forM imps $ \imp -> do
-                        imp' <- source imp
-                        matchExpr imp' $ \case
-                            Import a _ -> do
-                                a' <- source a
-                                matchExpr a' $ \case
-                                    ImportSrc n -> case n of
-                                        Term.Absolute n -> do
-                                            let n' = convert n
-                                            return $ convert $ nameToString n'
+getImportsInFile = matchUnit =<< use Graph.clsClass where
+    matchUnit unit = matchExpr unit $ \(Unit imps _ _) -> 
+        matchImports =<< source imps
+    matchImports imps = matchExpr imps $ \(ImportHub imps') -> 
+        mapM matchImport =<< mapM source =<< ptrListToList imps'
+    matchImport imp = matchExpr imp $ \(Import absolute _) -> 
+        matchAbsolute =<< source absolute
+    matchAbsolute a = matchExpr a $ \(ImportSrc (Term.Absolute n)) -> 
+        pure . convert . nameToString $ convert n
 
 getAvailableImports :: GraphLocation -> Empire (Set ImportName)
-getAvailableImports (GraphLocation file _) = withUnit (GraphLocation file (Breadcrumb [])) $ do
-    explicitImports <- fromList <$> runASTOp getImportsInFile
-    let implicitImports = fromList [nativeModuleName, "Std.Base"]
-    pure $ explicitImports <> implicitImports
+getAvailableImports gl = withUnit pureGl mkImports where
+    pureGl = GraphLocation (gl ^. GraphLocation.filePath) mempty
+    implicitImports = [nativeModuleName, "Std.Base"]
+    mkImports = fromList . (implicitImports <>) <$> runASTOp getImportsInFile
 
 classToHints :: Class.Class -> ClassHints
-classToHints (Class.Class constructors methods _) = ClassHints cons' meth'
-    where
-        getDoc = fromMaybe def . view Def.documentation
-        cons'  = ((, def) . convert) <$> Map.keys constructors
-        meth'  = (convert *** getDoc) <$> (filter (isPublicMethod . fst) $ Map.toList $ unwrap methods)
+classToHints (Class.Class constructors methods _) 
+    = ClassHints constructorsHints methodsHints where
+        getDocumentation  = fromMaybe mempty . view Def.documentation
+        constructorsHints = ((, mempty) . convert) <$> Map.keys constructors
+        methodsHints      = (convert *** getDocumentation) <$> 
+            filter (isPublicMethod . fst) (Map.toList $ unwrap methods)
 
 isPublicMethod :: IR.Name -> Bool
 isPublicMethod (nameToString -> n) = Safe.headMay n /= Just '_'

--- a/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
+++ b/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
@@ -82,19 +82,21 @@ buildGraph = do
     connections <- buildConnections
     nodes       <- buildNodes
     (inE, outE) <- buildEdgeNodes
-    API.Graph
+    monads      <- buildMonads
+    pure $ API.Graph
         nodes
         (uncurry API.Connection <$> connections)
         (Just inE)
         (Just outE)
-        <$> buildMonads
+        monads
+        mempty
 
 buildClassGraph :: ClassOp API.Graph
 buildClassGraph = do
     funs <- use Graph.clsFuns
     nodes' <- mapM (\(uuid, funGraph)
         -> buildClassNode uuid (funGraph ^. Graph.funName)) $ Map.assocs funs
-    pure $ API.Graph nodes' mempty mempty mempty mempty
+    pure $ API.Graph nodes' mempty mempty mempty mempty mempty
 
 
 buildClassNode :: NodeId -> String -> ClassOp API.ExpressionNode

--- a/libs/luna-empire/test/CaseSpec.hs
+++ b/libs/luna-empire/test/CaseSpec.hs
@@ -1,49 +1,46 @@
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module CaseSpec (spec) where
 
-import           Control.Lens                  ((^..))
-import           Data.Foldable                 (toList)
-import           Data.List                     (find, stripPrefix)
-import qualified Data.Map                      as Map
-import qualified LunaStudio.Data.Graph         as Graph
-import qualified Empire.Data.Graph             as Graph (breadcrumbHierarchy)
-import           LunaStudio.Data.Connection    (Connection(..))
-import           LunaStudio.Data.GraphLocation (GraphLocation(..))
-import qualified LunaStudio.Data.Node          as Node
-import           LunaStudio.Data.NodeMeta      (NodeMeta(..))
-import qualified LunaStudio.Data.Port          as Port
-import           LunaStudio.Data.Port          (OutPortTree (..))
-import           LunaStudio.Data.NodeLoc       (NodeLoc (..))
-import           LunaStudio.Data.PortDefault   (PortDefault (Constant, Expression))
-import           LunaStudio.Data.LabeledTree   (LabeledTree (..))
-import           LunaStudio.Data.PortRef       (InPortRef (..), OutPortRef (..), AnyPortRef(..))
-import           LunaStudio.Data.TypeRep       (TypeRep(TCons, TStar, TLam, TVar))
-import           Empire.ASTOp                  (runASTOp)
-import qualified Empire.ASTOps.Deconstruct     as ASTDeconstruct
-import qualified Empire.ASTOps.Parse           as Parser
-import           Empire.ASTOps.Print           (printExpression)
-import qualified Empire.ASTOps.Read            as ASTRead
-import qualified Empire.Commands.AST           as AST (isTrivialLambda)
-import           Empire.Data.BreadcrumbHierarchy (BreadcrumbDoesNotExistException)
-import qualified Empire.Commands.Graph         as Graph (addNode, connect, getGraph, getNodes,
-                                                         getConnections, removeNodes, withGraph,
-                                                         renameNode, disconnect, addPort, movePort,
-                                                         removePort, renamePort)
+import           Control.Lens                    ((^..))
+import           Data.Foldable                   (toList)
+import           Data.List                       (find, stripPrefix)
+import qualified Data.Map                        as Map
+import           Empire.ASTOp                    (runASTOp)
+import qualified Empire.ASTOps.Deconstruct       as ASTDeconstruct
+import qualified Empire.ASTOps.Parse             as Parser
+import           Empire.ASTOps.Print             (printExpression)
+import qualified Empire.ASTOps.Read              as ASTRead
+import qualified Empire.Commands.AST             as AST (isTrivialLambda)
+import qualified Empire.Commands.Graph           as Graph (addNode, addPort, connect, disconnect, getConnections, getGraph, getNodes,
+                                                           movePort, removeNodes, removePort, renameNode, renamePort, withGraph)
 import qualified Empire.Commands.GraphBuilder    as GraphBuilder
 import           Empire.Commands.Library         (withLibrary)
 import qualified Empire.Commands.Typecheck       as Typecheck (run)
-import           Empire.Data.Graph               (breadcrumbHierarchy)
-import qualified Empire.Data.Library             as Library (body)
+import           Empire.Data.BreadcrumbHierarchy (BreadcrumbDoesNotExistException)
 import qualified Empire.Data.BreadcrumbHierarchy as BH
-import           Empire.Empire                   (InterpreterEnv(..))
+import           Empire.Data.Graph               (breadcrumbHierarchy)
+import qualified Empire.Data.Graph               as Graph (breadcrumbHierarchy)
+import qualified Empire.Data.Library             as Library (body)
+import           Empire.Empire                   (InterpreterEnv (..))
+import           LunaStudio.Data.Connection      (Connection (..))
+import qualified LunaStudio.Data.Graph           as Graph
+import           LunaStudio.Data.GraphLocation   (GraphLocation (..))
+import           LunaStudio.Data.LabeledTree     (LabeledTree (..))
+import qualified LunaStudio.Data.Node            as Node
+import           LunaStudio.Data.NodeLoc         (NodeLoc (..))
+import           LunaStudio.Data.NodeMeta        (NodeMeta (..))
+import           LunaStudio.Data.Port            (OutPortTree (..))
+import qualified LunaStudio.Data.Port            as Port
+import           LunaStudio.Data.PortDefault     (PortDefault (Constant, Expression))
+import           LunaStudio.Data.PortRef         (AnyPortRef (..), InPortRef (..), OutPortRef (..))
+import           LunaStudio.Data.TypeRep         (TypeRep (TCons, TLam, TStar, TVar))
 import           Prologue                        hiding (mapping, toList, (|>))
 -- import           OCI.IR.Class                    (exprs, links)
 
-import           Test.Hspec (Spec, Selector, around, describe, expectationFailure, it, parallel,
-                             shouldBe, shouldContain, shouldSatisfy, shouldMatchList,
-                             shouldStartWith, shouldThrow, xit, xdescribe)
+import           Test.Hspec                      (Selector, Spec, around, describe, expectationFailure, it, parallel, shouldBe,
+                                                  shouldContain, shouldMatchList, shouldSatisfy, shouldStartWith, shouldThrow, xdescribe,
+                                                  xit)
 
 import           EmpireUtils
 
@@ -75,7 +72,7 @@ spec = around withChannels $ parallel $ do
                     , Port.Port [Port.Self]  "self" TStar Port.NotConnected
                     , Port.Port [Port.Arg 0] "arg0" TStar (Port.WithDefault (Expression "x: x"))
                     ]
-                let Graph.Graph nodes connections (Just inputEdge) (Just outputEdge) _ = graph
+                let Graph.Graph nodes connections (Just inputEdge) (Just outputEdge) _ _ = graph
                 (inputEdge ^. Node.inputEdgePorts) `shouldMatchList` [
                       LabeledTree def (Port.Port [Port.Projection 0] "x" TStar Port.NotConnected)
                     ]

--- a/libs/luna-empire/test/EmpireSpec.hs
+++ b/libs/luna-empire/test/EmpireSpec.hs
@@ -53,7 +53,7 @@ import           LunaStudio.Data.Port            (InPorts (..), OutPorts (..))
 import qualified LunaStudio.Data.Port            as Port
 import           LunaStudio.Data.PortDefault     (PortDefault (Expression))
 import           LunaStudio.Data.PortRef         (AnyPortRef (..), InPortRef (..), OutPortRef (..))
-import qualified LunaStudio.Data.PortRef            as PortRef
+import qualified LunaStudio.Data.PortRef         as PortRef
 import qualified LunaStudio.Data.Position        as Position
 import           LunaStudio.Data.TypeRep         (TypeRep (TCons, TLam, TStar, TVar))
 -- import           OCI.IR.Class                    (exprs, links)
@@ -103,7 +103,7 @@ spec = around withChannels $ parallel $ do
                 topLevel <- graphIDs top
                 n1Level  <- Graph.getGraph (top |> u1)
                 return (topLevel, n1Level)
-            withResult res $ \(topLevel, Graph.Graph n1LevelNodes _ i o _) -> do
+            withResult res $ \(topLevel, Graph.Graph n1LevelNodes _ i o _ _) -> do
                 length topLevel `shouldBe` 1
                 topLevel `shouldContain` [u1]
                 i            `shouldSatisfy` isJust
@@ -116,7 +116,7 @@ spec = around withChannels $ parallel $ do
                 topLevel <- graphIDs top
                 n1Level <- Graph.getGraph (top |> u1)
                 return (topLevel, n1Level)
-            withResult res $ \(topLevel, Graph.Graph n1LevelNodes _ i o _) -> do
+            withResult res $ \(topLevel, Graph.Graph n1LevelNodes _ i o _ _) -> do
                 length topLevel `shouldBe` 1
                 topLevel `shouldContain` [u1]
                 i            `shouldSatisfy` isJust
@@ -743,7 +743,7 @@ spec = around withChannels $ parallel $ do
                 Graph.setNodeExpression top u1 "a: b: a + b"
                 Graph.getGraph (top |> u1)
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                 let [node] = nodes
                 node ^. Node.expression `shouldBe` "• + •"
                 connections `shouldSatisfy` ((== 3) . length)
@@ -1571,7 +1571,7 @@ spec = around withChannels $ parallel $ do
                       Port.Port []           "alias" TStar (Port.WithDefault $ Expression "(Foobar a b c): b")
                     , Port.Port [Port.Arg 0] "arg0" TStar Port.NotConnected
                     ]
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                 nodes `shouldBe` mempty
                 input ^.. Node.inputEdgePorts . traverse . traverse `shouldMatchList` [
                       Port.Port [Port.Projection 0]                    "Foobar a b c" TStar Port.NotConnected
@@ -1603,7 +1603,7 @@ spec = around withChannels $ parallel $ do
                     , Port.Port [Port.Arg 1] "x"    TStar Port.NotConnected
                     , Port.Port [Port.Arg 2] "arg2" TStar Port.NotConnected
                     ]
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                 nodes `shouldBe` mempty
                 input ^.. Node.inputEdgePorts . traverse . traverse `shouldMatchList` [
                       Port.Port [Port.Projection 0]                                       "Foobar a b (Just c)" TStar Port.NotConnected

--- a/libs/luna-empire/test/FileLoadSpec.hs
+++ b/libs/luna-empire/test/FileLoadSpec.hs
@@ -62,6 +62,7 @@ import           LunaStudio.Data.Connection      (Connection (..))
 import           LunaStudio.Data.Diff            (Diff (..))
 import qualified LunaStudio.Data.Graph           as Graph
 import           LunaStudio.Data.GraphLocation   (GraphLocation (..))
+import qualified LunaStudio.Data.GraphLocation   as GraphLocation
 import qualified LunaStudio.Data.Node            as Node
 import           LunaStudio.Data.NodeLoc         (NodeLoc (..))
 import           LunaStudio.Data.NodeMeta        (NodeMeta (..))
@@ -229,7 +230,7 @@ spec = around withChannels $ parallel $ do
                 let loc' = GraphLocation "TestPath" $ Breadcrumb [Definition (main ^. Node.nodeId)]
                 graph <- Graph.withGraph loc' $ runASTOp $ GraphBuilder.buildGraph
                 return graph
-            withResult res $ \(Graph.Graph nodes connections i _ _) -> do
+            withResult res $ \(Graph.Graph nodes connections i _ _ _) -> do
                 let Just pi = find (\node -> node ^. Node.name == Just "pi") nodes
                 pi ^. Node.code `shouldBe` "3.14"
                 pi ^. Node.canEnter `shouldBe` False
@@ -266,7 +267,7 @@ def main:
                 let loc' = GraphLocation "TestPath" $ Breadcrumb [Definition (main ^. Node.nodeId)]
                 graph <- Graph.withGraph loc' $ runASTOp $ GraphBuilder.buildGraph
                 return graph
-            withResult res $ \(Graph.Graph nodes connections i _ _) -> do
+            withResult res $ \(Graph.Graph nodes connections i _ _ _) -> do
                 let Just pi = find (\node -> node ^. Node.name == Just "pi") nodes
                 pi ^. Node.code `shouldBe` "3.14"
                 pi ^. Node.canEnter `shouldBe` False
@@ -280,7 +281,7 @@ def main:
                 Graph.substituteCode "TestPath" [(71, 71, "3")]
                 Graph.getGraph loc'
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                     cNodes = filter (\node -> node ^. Node.name == Just "c") nodes
                 length cNodes `shouldBe` 1
                 let [cNode] = cNodes
@@ -301,7 +302,7 @@ def main:
                 Graph.substituteCode "TestPath" [(71, 71, "3")]
                 Graph.getGraph loc'
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                     cNodes = filter (\node -> node ^. Node.name == Just "c") nodes
                 length nodes `shouldBe` 4
                 length cNodes `shouldBe` 1
@@ -324,7 +325,7 @@ def main:
                 Graph.substituteCode "TestPath" [(91, 91, "1")]
                 Graph.getGraph loc'
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                     cNodes = filter (\node -> node ^. Node.name == Just "c") nodes
                 length nodes `shouldBe` 4
                 length cNodes `shouldBe` 1
@@ -347,7 +348,7 @@ def main:
                 Graph.substituteCode "TestPath" [(92, 92, "    d = 10\n")]
                 Graph.getGraph loc'
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                     Just d = find (\node -> node ^. Node.name == Just "d") nodes
                 d ^. Node.code `shouldBe` "10"
                 let Just c = find (\node -> node ^. Node.name == Just "c") nodes
@@ -409,7 +410,7 @@ def main:
                 Graph.substituteCode "TestPath" [(25, 26, "5")]
                 Graph.getGraph loc'
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                     Just pi = find (\node -> node ^. Node.name == Just "pi") nodes
                     Just c = find (\node -> node ^. Node.name == Just "c") nodes
                     Just bar = find (\node -> node ^. Node.name == Just "bar") nodes
@@ -436,7 +437,7 @@ def main:
                 Just foo <- Graph.withGraph loc' $ runASTOp $ Graph.getNodeIdForMarker 0
                 Graph.withGraph (loc' |> foo) $ runASTOp $ GraphBuilder.buildGraph
             withResult res $ \graph -> do
-                let Graph.Graph nodes connections _ _ _ = graph
+                let Graph.Graph nodes connections _ _ _ _ = graph
                 nodes `shouldSatisfy` ((== 1) . length)
                 connections `shouldSatisfy` ((== 3) . length)
         it "lambda in code can be entered" $ \env -> do
@@ -452,7 +453,7 @@ def main:
                 let loc' = GraphLocation "TestPath" $ Breadcrumb [Definition (main ^. Node.nodeId)]
                 Just foo <- Graph.withGraph loc' $ runASTOp $ Graph.getNodeIdForMarker 0
                 Graph.getGraph $ loc' |> foo
-            withResult res $ \(Graph.Graph nodes connections _ _ _) -> do
+            withResult res $ \(Graph.Graph nodes connections _ _ _ _) -> do
                 nodes `shouldBe` mempty
                 connections `shouldSatisfy` (not . null)
         it "autolayouts nodes on file load" $ \env -> do
@@ -508,7 +509,7 @@ def main:
                 [main] <- Graph.getNodes loc
                 let loc' = loc |>= main ^. Node.nodeId
                 Just foo <- Graph.withGraph loc' $ runASTOp (Graph.getNodeIdForMarker 1)
-                before@(Graph.Graph _ _ (Just input) _ _) <- Graph.getGraph $ loc' |> foo
+                before@(Graph.Graph _ _ (Just input) _ _ _) <- Graph.getGraph $ loc' |> foo
                 Graph.movePort (loc' |> foo) (outPortRef (input ^. Node.nodeId) [Port.Projection 0]) 1
                 Graph.movePort (loc' |> foo) (outPortRef (input ^. Node.nodeId) [Port.Projection 0]) 1
                 after <- Graph.getGraph $ loc' |> foo
@@ -522,7 +523,7 @@ def main:
                 [main] <- Graph.getNodes loc
                 let loc' = loc |>= main ^. Node.nodeId
                 Just foo <- Graph.withGraph loc' $ runASTOp (Graph.getNodeIdForMarker 1)
-                before@(Graph.Graph _ _ (Just input) _ _) <- Graph.getGraph $ loc' |> foo
+                before@(Graph.Graph _ _ (Just input) _ _ _) <- Graph.getGraph $ loc' |> foo
                 Graph.movePort (loc' |> foo) (outPortRef (input ^. Node.nodeId) [Port.Projection 0]) 1
                 code <- Graph.withUnit loc $ use Graph.code
                 return code

--- a/libs/luna-empire/test/FileModuleSpec.hs
+++ b/libs/luna-empire/test/FileModuleSpec.hs
@@ -721,7 +721,7 @@ spec = around withChannels $ parallel $ do
                 let Just bar = view Node.nodeId <$> find (\n -> n ^. Node.name == Just "bar") nodes
                 u1 <- mkUUID
                 Graph.addNode (loc |>= bar) u1 "5" (atXPos 10)
-                APIGraph.Graph _ _ _ (Just output) _ <- Graph.getGraph (loc |>= bar)
+                APIGraph.Graph _ _ _ (Just output) _ _ <- Graph.getGraph (loc |>= bar)
                 Graph.connect (loc |>= bar) (outPortRef u1 []) (InPortRef' $ inPortRef (output ^. Node.nodeId) [])
                 u2 <- mkUUID
                 Graph.addNode (loc |>= bar) u2 "1" (atXPos (-20))
@@ -751,7 +751,7 @@ spec = around withChannels $ parallel $ do
                 let Just bar = view Node.nodeId <$> find (\n -> n ^. Node.name == Just "bar") nodes
                 u1 <- mkUUID
                 Graph.addNode (loc |>= bar) u1 "5" (atXPos 10)
-                APIGraph.Graph _ _ _ (Just output) _ <- Graph.getGraph (loc |>= bar)
+                APIGraph.Graph _ _ _ (Just output) _ _ <- Graph.getGraph (loc |>= bar)
                 Graph.connect (loc |>= bar) (outPortRef u1 []) (InPortRef' $ inPortRef (output ^. Node.nodeId) [])
                 blockEnd <- Graph.withGraph (loc |>= bar) $ runASTOp $ Code.getCurrentBlockEnd
                 code <- Graph.withUnit loc $ use Graph.code
@@ -919,7 +919,7 @@ spec = around withChannels $ parallel $ do
                         4
                     |]
             in specifyCodeChange initialCode initialCode $ \loc -> do
-                imports <- Graph.getAvailableImports loc
+                imports <- Graph.getAvailableImports $ loc
                 liftIO $ imports `shouldBe` fromList ["Std.Base", "Std.Geo", "Native"]
         it "shows implicit imports as always imported" $
             let initialCode = [r|

--- a/libs/luna-empire/test/FileModuleSpec.hs
+++ b/libs/luna-empire/test/FileModuleSpec.hs
@@ -919,7 +919,7 @@ spec = around withChannels $ parallel $ do
                         4
                     |]
             in specifyCodeChange initialCode initialCode $ \loc -> do
-                imports <- Graph.getAvailableImports $ loc
+                imports <- Graph.getAvailableImports loc
                 liftIO $ imports `shouldBe` fromList ["Std.Base", "Std.Geo", "Native"]
         it "shows implicit imports as always imported" $
             let initialCode = [r|

--- a/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
@@ -1,6 +1,6 @@
 module LunaStudio.Data.Diff where
 
-import           Control.Lens                         (_Right, makePrisms)
+import           Control.Lens                         (makePrisms, _Right)
 import           Data.Aeson.Types                     (ToJSON)
 import           Data.Binary                          (Binary)
 import           Data.HashMap.Strict                  (HashMap)
@@ -461,6 +461,7 @@ instance Diffable Graph where
     patch mod@(RenameNode       _) g = g & Graph.nodes         %~ patch mod
     patch mod@(SetCanEnterNode  _) g = g & Graph.nodes         %~ patch mod
     patch mod@(SetExpression    _) g = g & Graph.nodes         %~ patch mod
+    patch mod@(SetImports       _) g = g & Graph.imports       %~ patch mod
     patch mod@(SetInPorts       _) g = g & Graph.nodes         %~ patch mod
     patch     (SetInputSidebar  m) g = g & Graph.inputSidebar  .~ m ^. newInputSidebar
     patch mod@(SetIsDefinition  _) g = g & Graph.nodes         %~ patch mod
@@ -470,7 +471,7 @@ instance Diffable Graph where
     patch mod@(SetOutPorts      _) g = g & Graph.nodes         %~ patch mod
     patch     (SetOutputSidebar m) g = g & Graph.outputSidebar .~ m ^. newOutputSidebar
     patch     _                    g = g
-    diff g1 g2 = nodesDiff <> inSidebarDiff <> outSidebarDiff <> connsDiff <> monadsDiff where
+    diff g1 g2 = nodesDiff <> inSidebarDiff <> outSidebarDiff <> connsDiff <> monadsDiff <> importsDiff where
         nodesDiff     = diff (g1 ^. Graph.nodes) (g2 ^. Graph.nodes)
         connsDiff     = diff (g1 ^. Graph.connections) (g2 ^. Graph.connections)
         inSidebarDiff = Diff $ if g1 ^. Graph.inputSidebar /= g2 ^. Graph.inputSidebar
@@ -481,6 +482,9 @@ instance Diffable Graph where
             else mempty
         monadsDiff     = Diff $ if g1 ^. Graph.monads /= g2 ^. Graph.monads
             then pure . toModification . ModificationSetMonadPath $ g2 ^. Graph.monads
+            else mempty
+        importsDiff    = Diff $ if g1 ^. Graph.imports /= g2 ^. Graph.imports
+            then pure . toModification . ModificationSetImports $ g2 ^. Graph.imports
             else mempty
 
 instance Diffable (Either (Error GraphError) Graph) where

--- a/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
@@ -554,7 +554,7 @@ instance Diffable GUIState where
     patch mod@(SetExpression         _) s = s & GUIState.graph . _Right         %~ patch mod
     patch     (SetGraph              m) s = s & GUIState.graph                  .~ Right (m ^. newGraph)
     patch     (SetGraphError         m) s = s & GUIState.graph                  .~ Left  (m ^. graphError)
-    patch     (SetImports            m) s = s & GUIState.imports                .~ m ^. newImports
+    patch mod@(SetImports            _) s = s & GUIState.graph . _Right         %~ patch mod
     patch mod@(SetInPorts            _) s = s & GUIState.graph . _Right         %~ patch mod
     patch mod@(SetInputSidebar       _) s = s & GUIState.graph . _Right         %~ patch mod
     patch mod@(SetIsDefinition       _) s = s & GUIState.graph . _Right         %~ patch mod
@@ -572,7 +572,6 @@ instance Diffable GUIState where
                 (Left  _ , Right g ) -> Diff . pure . toModification $ ModificationSetGraph      g
                 (Right g1, Right g2) -> diff g1 g2
         result = diff (s1 ^. GUIState.breadcrumb)             (s2 ^. GUIState.breadcrumb)
-              <> diff (s1 ^. GUIState.imports)                (s2 ^. GUIState.imports)
               <> diff (s1 ^. GUIState.defaultVisualizers)     (s2 ^. GUIState.defaultVisualizers)
               <> diff (s1 ^. GUIState.camera)                 (s2 ^. GUIState.camera)
               <> diff (s1 ^. GUIState.projectVisualizersPath) (s2 ^. GUIState.projectVisualizersPath)
@@ -584,12 +583,10 @@ instance Diffable GUIState where
 
 
 guiStateDiff :: GUIState -> Diff
-guiStateDiff s = mconcat [bcDiff, impsDiff, defVisDiff, camDiff, visPathDiff,
-    codeDiff, graphDiff] where
+guiStateDiff s = mconcat [bcDiff, defVisDiff, camDiff, visPathDiff, codeDiff,
+    graphDiff] where
         bcDiff      = toDiff . ModificationSetBreadcrumb
                     $ s ^. GUIState.breadcrumb
-        impsDiff    = toDiff . ModificationSetImports
-                    $ s ^. GUIState.imports
         defVisDiff  = toDiff . ModificationSetDefaultVisualizers
                     $ s ^. GUIState.defaultVisualizers
         camDiff     = toDiff . ModificationSetCamera

--- a/libs/luna-studio-common/src/LunaStudio/Data/GUIState.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/GUIState.hs
@@ -19,7 +19,6 @@ import           Prologue                             hiding (TypeRep)
 
 data GUIState = GUIState
     { _breadcrumb             :: Breadcrumb (Named BreadcrumbItem)
-    , _imports                :: Set ImportName
     , _defaultVisualizers     :: HashMap TypeRep Visualizer
     , _camera                 :: CameraTransformation
     , _projectVisualizersPath :: Maybe FilePath

--- a/libs/luna-studio-common/src/LunaStudio/Data/Graph.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Graph.hs
@@ -1,10 +1,12 @@
 module LunaStudio.Data.Graph where
 
-import           Data.Aeson.Types           (FromJSON, ToJSON)
-import           Data.Binary                (Binary)
-import           LunaStudio.Data.Connection (Connection)
-import           LunaStudio.Data.MonadPath  (MonadPath)
-import           LunaStudio.Data.Node       (ExpressionNode, InputSidebar, OutputSidebar)
+import           Data.Aeson.Types             (FromJSON, ToJSON)
+import           Data.Binary                  (Binary)
+import           Data.Set                     (Set)
+import           LunaStudio.Data.Connection   (Connection)
+import           LunaStudio.Data.MonadPath    (MonadPath)
+import           LunaStudio.Data.Node         (ExpressionNode, InputSidebar, OutputSidebar)
+import           LunaStudio.Data.NodeSearcher (ImportName)
 import           Prologue
 
 
@@ -14,6 +16,7 @@ data Graph = Graph
     , _inputSidebar  :: Maybe InputSidebar
     , _outputSidebar :: Maybe OutputSidebar
     , _monads        :: [MonadPath]
+    , _imports       :: Set ImportName
     } deriving (Eq, Generic, Show)
 
 makeLenses ''Graph
@@ -24,4 +27,4 @@ instance FromJSON Graph
 instance ToJSON   Graph
 
 instance Default Graph where
-    def = Graph def def def def def
+    def = Graph def def def def def def

--- a/libs/luna-studio-common/src/LunaStudio/Data/NodeSearcher.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/NodeSearcher.hs
@@ -2,6 +2,7 @@ module LunaStudio.Data.NodeSearcher
     ( module LunaStudio.Data.NodeSearcher
     , RawEntry (..)
     , Match (..)
+    , MatchType (..)
     , EntryType (..)
     , ClassName
     , ImportName
@@ -15,7 +16,7 @@ module LunaStudio.Data.NodeSearcher
     , weight
     , score
     , charsMatch
-    , exactMatch
+    , matchType
     , className
     , importName
     , imported
@@ -30,9 +31,9 @@ import qualified Data.Map         as Map
 import           Data.Set         (Set)
 import qualified Data.Set         as Set
 import           Data.Text        (Text)
-import           FuzzyText        (ClassName, EntryType (..), ImportInfo (ImportInfo), ImportName, Match (..), Query, Range, RawEntry (..),
-                                   Score, charsMatch, className, doc, entryType, exactMatch, fuzzySearch, importInfo, importName, imported,
-                                   name, score, weight)
+import           FuzzyText        (ClassName, EntryType (..), ImportInfo (ImportInfo), ImportName, Match (..), MatchType (..), Query, Range,
+                                   RawEntry (..), Score, charsMatch, className, doc, entryType, fuzzySearch, importInfo, importName,
+                                   imported, matchType, name, score, weight)
 import           Prologue         hiding (Item)
 
 type Name = Text
@@ -78,7 +79,7 @@ missingImports = to missingImports' where
             in Set.filter (`Set.notMember` neededImports) currentImps
 
 
-data TypePreferation = TypePreferation
+data TypePreference = TypePreference
     { _localFunctionsWeight         :: Double
     , _globalFunctionsWeight        :: Double
     , _specialWeightForClassMethods :: (Set ClassName, Double)
@@ -86,17 +87,17 @@ data TypePreferation = TypePreferation
     , _constructorsWeight           :: Double
     } deriving Show
 
-makeLenses ''TypePreferation
-instance Default TypePreferation where def = TypePreferation 1 1 (def, 1) 1 1
+makeLenses ''TypePreference
+instance Default TypePreference where def = TypePreference 1 1 (def, 1) 1 1
 
 searchCommands :: Query -> [Text] -> [Match]
 searchCommands q = fuzzySearch q . fmap (\c -> RawEntry c def Command 1 def)
 
-search :: Query -> NodeSearcherData -> Maybe TypePreferation -> [Match]
+search :: Query -> NodeSearcherData -> Maybe TypePreference -> [Match]
 search q nsData tp = fuzzySearch q $ toEntries nsData (fromJust def tp)
 
 
-toEntries :: NodeSearcherData -> TypePreferation -> [RawEntry]
+toEntries :: NodeSearcherData -> TypePreference -> [RawEntry]
 toEntries (NodeSearcherData ih currImps) tPref
     = concat . Map.elems $ Map.mapWithKey moduleHintsToEntries ih where
         moduleHintsToEntries :: ImportName -> ModuleHints -> [RawEntry]

--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/CreateGraph.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/CreateGraph.hs
@@ -1,40 +1,43 @@
 module NodeEditor.Action.Basic.CreateGraph where
 
-import           Common.Action.Command                 (Command)
+import           Common.Action.Command                       (Command)
 import           Common.Prelude
-import qualified Data.Set                              as Set
-import           LunaStudio.Data.Connection            (Connection)
-import qualified LunaStudio.Data.Connection            as Connection
-import           LunaStudio.Data.Graph                 (Graph)
-import qualified LunaStudio.Data.Graph                 as API
-import           LunaStudio.Data.MonadPath             (MonadPath)
-import           LunaStudio.Data.NodeLoc               (NodePath)
-import           NodeEditor.Action.Basic.AddConnection (localAddConnections)
-import           NodeEditor.Action.Basic.FocusNode     (updateNodeZOrder)
-import           NodeEditor.Action.Basic.RemoveNode    (localRemoveNodes)
-import           NodeEditor.Action.Basic.UpdateNode    (localUpdateOrAddExpressionNode, localUpdateOrAddInputNode,
-                                                        localUpdateOrAddOutputNode)
-import           NodeEditor.Action.State.NodeEditor    (getExpressionNodes, modifyNodeEditor,
-                                                        setGraphStatus, updateMonads)
-import           NodeEditor.React.Model.Node           (ExpressionNode, InputNode, OutputNode, nodeLoc)
-import qualified NodeEditor.React.Model.NodeEditor     as NE
-import           NodeEditor.State.Global               (State)
+import           Data.Set                                    (Set)
+import qualified Data.Set                                    as Set
+import           LunaStudio.Data.Connection                  (Connection)
+import qualified LunaStudio.Data.Connection                  as Connection
+import           LunaStudio.Data.Graph                       (Graph)
+import qualified LunaStudio.Data.Graph                       as API
+import           LunaStudio.Data.MonadPath                   (MonadPath)
+import           LunaStudio.Data.NodeLoc                     (NodePath)
+import           LunaStudio.Data.NodeSearcher                (ImportName)
+import           NodeEditor.Action.Basic.AddConnection       (localAddConnections)
+import           NodeEditor.Action.Basic.FocusNode           (updateNodeZOrder)
+import           NodeEditor.Action.Basic.RemoveNode          (localRemoveNodes)
+import           NodeEditor.Action.Basic.UpdateNode          (localUpdateOrAddExpressionNode, localUpdateOrAddInputNode,
+                                                              localUpdateOrAddOutputNode)
+import           NodeEditor.Action.Basic.UpdateSearcherHints (setCurrentImports)
+import           NodeEditor.Action.State.NodeEditor          (getExpressionNodes, modifyNodeEditor, setGraphStatus, updateMonads)
+import           NodeEditor.React.Model.Node                 (ExpressionNode, InputNode, OutputNode, nodeLoc)
+import qualified NodeEditor.React.Model.NodeEditor           as NE
+import           NodeEditor.State.Global                     (State)
 
 
 
 updateWithAPIGraph :: NodePath -> Graph -> Command State ()
-updateWithAPIGraph p g = updateGraph nodes input output conns monads
+updateWithAPIGraph p g = updateGraph nodes input output conns monads imports
     >> setGraphStatus NE.GraphLoaded where
-        nodes  = convert . (p,) <$> g ^. API.nodes
-        input  = convert . (p,) <$> g ^. API.inputSidebar
-        output = convert . (p,) <$> g ^. API.outputSidebar
-        conns  = Connection.prependPath p <$> g ^. API.connections
-        monads = g ^. API.monads
+        nodes   = convert . (p,) <$> g ^. API.nodes
+        input   = convert . (p,) <$> g ^. API.inputSidebar
+        output  = convert . (p,) <$> g ^. API.outputSidebar
+        conns   = Connection.prependPath p <$> g ^. API.connections
+        monads  = g ^. API.monads
+        imports = g ^. API.imports
 
 
 updateGraph :: [ExpressionNode] -> Maybe InputNode -> Maybe OutputNode
-    -> [Connection] -> [MonadPath] -> Command State ()
-updateGraph nodes input output connections monads = do
+    -> [Connection] -> [MonadPath] -> Set ImportName -> Command State ()
+updateGraph nodes input output connections monads imports = do
     let nlsSet = Set.fromList $ map (view nodeLoc) nodes
     nlsToRemove <- filter (not . flip Set.member nlsSet) . map (view nodeLoc)
         <$> getExpressionNodes
@@ -53,4 +56,5 @@ updateGraph nodes input output connections monads = do
     void $ localAddConnections connections
 
     updateMonads monads
+    setCurrentImports imports
     updateNodeZOrder

--- a/luna-studio/stack.yaml
+++ b/luna-studio/stack.yaml
@@ -44,7 +44,7 @@ packages:
 - extra-dep: true
   location: {commit: 1c6a4fd165e4b15cad114b0a554e0974fd119223, git: 'git@github.com:luna/functor-utils.git'}
 - extra-dep: true
-  location: {commit: 8babf4c65507fa7608e6c6468be4fcabddf77327, git: 'git@github.com:luna/fuzzy-text.git'}
+  location: {commit: 1fe94d4d8b106b2ab37c65de9200b3f0404ac2ca, git: 'git@github.com:luna/fuzzy-text.git'}
 - extra-dep: true
   location: {commit: a1606cccc12cb521acbc598e52c481b9054b42a7, git: 'git@github.com:luna/impossible.git'}
 - extra-dep: true


### PR DESCRIPTION
### Pull Request Description

This PR is first part of series of improvements to searcher. Searcher now is always informed about imports changes therefore can propose hints better (based on information if given module is imported). Also with [this commit](https://github.com/luna/fuzzy-text/commit/1fe94d4d8b106b2ab37c65de9200b3f0404ac2ca) it develops sorting of hints so perfect match can always appear first. This is a temporary solution and it's meant to be replaced with proper scoring.

This PR should be considered as a solution to: [bug about not updated info about imports](https://github.com/luna/luna-studio/issues/1086) and [alternative proposal to exact match always being displayed first](https://github.com/luna/luna-studio/issues/1075).

The main values of this PR are:
- searcher is immediately updated when library is imported so we can score their contents higher right away
- when there is a hint matching exactly users input it will be positioned as first hint if it comes from imported module. This way we invite users to use already imported libraries (which they usually want to do) but allowing them to see and select other hint which will result in new import. With previous improvement this hint will be much higher scored in next search.

### Important Notes

- The minimal representation of graph now also contains info about available imports
- LunaStudio.Data.Graph now has a new field called `imports`. This class is very basic so it is important change but shouldn't affect user in any way (this is internal luna-studio class).

### Checklist
Please include the following checklist in your PR:

- [  ] The documentation has been updated if necessary.
- [  ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [  ] The code has been tested where possible.