### PR TITLE
[Bootstrap] Fix the directories during Python installation

### DIFF
--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -8,7 +8,7 @@ import qualified Shelly.Lifted as Shelly
 import Shelly.Lifted (MonadSh, (</>), shelly, liftIO)
 import qualified System.Directory as System
 import Control.Monad.Catch (throwM, MonadThrow)
-import Control.Monad (when, unless, void)
+import Control.Monad (when, unless)
 import Control.Monad.IO.Class ( MonadIO)
 import Control.Exception (Exception)
 import Data.Maybe (fromMaybe)
@@ -92,9 +92,9 @@ installPython = do
             Shelly.setenv "LDFLAGS" $ "-L" <> opensslPath <> "/lib"
         Shelly.cmd "pyenv" "install" supportedPythonVersion
 
-    void $ Shelly.chdir (fromText current) $ do
+    Shelly.chdir (fromText current) $ do
         Shelly.cmd "pyenv" "local" supportedPythonVersion
-        Shelly.run "pip" ["install", "--user", "-r", "requirements.txt"]
+        Shelly.cmd "pip" "install" "--user" "-r" "requirements.txt"
 
 installNode :: (MonadIO m, MonadSh m, Shelly.MonadShControl m) => m ()
 installNode = do


### PR DESCRIPTION
### Pull Request Description

- Boostrap was failing on installing the requirements with pip
- The reason, as I suspect it, was that we were running the `pyenv local <pyversion>` command not in the project root (so, in most cases, `~/luna-develop/apps/luna-studio`, but inside `~/luna-develop/tools/python`. This in turn set the python version not for the Luna Studio project, but for the `python` folder...

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible:
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

