### PR TITLE
Fix incorrect ports for pattern match on custom datatype

### DIFF
--- a/libs/luna-empire/package.yaml
+++ b/libs/luna-empire/package.yaml
@@ -9,7 +9,7 @@ library:
 
 tests:
     spec:
-        main: Spec.hs
+        main: Main.hs
         source-dirs: test
         ghc-options: -Wno-unused-do-bind -threaded -with-rtsopts=-N4
         dependencies:

--- a/libs/luna-empire/test/FileModuleSpec.hs
+++ b/libs/luna-empire/test/FileModuleSpec.hs
@@ -927,7 +927,7 @@ spec = around withChannels $ parallel $ do
                         4
                     |]
             in specifyCodeChange initialCode expectedCode $ \_ -> do
-                let loc = GraphLocation "/TestPath" $ Breadcrumb []
+                let loc = GraphLocation "/TestProject" $ Breadcrumb []
                 nodes <- Graph.getNodes loc
                 let Just foo = (view Node.nodeId) <$> find (\n -> n ^. Node.name == Just "foo") nodes
                     loc' = loc |>= foo
@@ -950,7 +950,7 @@ spec = around withChannels $ parallel $ do
                         4
                     |]
             in specifyCodeChange initialCode expectedCode $ \_ -> do
-                let loc = GraphLocation "/TestPath" $ Breadcrumb []
+                let loc = GraphLocation "/TestProject" $ Breadcrumb []
                 nodes <- Graph.getNodes loc
                 let Just foo = (view Node.nodeId) <$> find (\n -> n ^. Node.name == Just "foo") nodes
                     loc' = loc |>= foo

--- a/libs/luna-empire/test/Main.hs
+++ b/libs/luna-empire/test/Main.hs
@@ -1,0 +1,31 @@
+module Main where
+
+import Empire.Prelude
+
+import qualified Language.Haskell.TH as TH
+import qualified Spec
+
+import Luna.Package.Structure.Name (lunaRootEnv)
+import System.Directory            (canonicalizePath, getCurrentDirectory)
+import System.Environment          (lookupEnv, setEnv)
+import System.FilePath             (takeDirectory, (</>))
+import Control.Exception (bracket)
+import Test.Hspec (hspec)
+
+
+main :: IO ()
+main = bracket setTestEnv unsetTestEnv (\_ -> hspec Spec.spec) where
+    setTestEnv = do
+        let testMainHsPath = $(do
+                dir      <- TH.runIO getCurrentDirectory
+                fileName <- TH.loc_filename <$> TH.location
+                TH.litE . TH.stringL $ dir </> fileName)
+            envDirName  = "env"
+            repoDirPath = takeDirectory testMainHsPath </> "../../.."
+            envDirPath  = repoDirPath </> envDirName
+        userLunaRoot   <- fromMaybe mempty <$> lookupEnv lunaRootEnv
+        mockedLunaRoot <- canonicalizePath envDirPath
+        setEnv lunaRootEnv mockedLunaRoot
+        pure userLunaRoot
+    unsetTestEnv = setEnv lunaRootEnv
+

--- a/libs/luna-empire/test/Spec.hs
+++ b/libs/luna-empire/test/Spec.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/libs/luna-empire/test/Test/Hspec/Empire.hs
+++ b/libs/luna-empire/test/Test/Hspec/Empire.hs
@@ -5,25 +5,41 @@ import Test.Hspec.Hspec.WithReason as X
 
 import Empire.Prelude
 
-import qualified Data.Text             as Text
-import qualified Empire.Commands.Graph as Graph
-import qualified Empire.Data.Graph     as Graph
+import qualified Data.Graph.Store              as Store
+import qualified Data.Text                     as Text
+import qualified Empire.Commands.Graph         as Graph
+import qualified Empire.Commands.Typecheck     as Typecheck (run)
+import qualified Empire.Data.Graph             as Graph
+import qualified Empire.Data.Library           as Library (body, path)
+import qualified Empire.Empire                 as Empire
+import qualified Language.Haskell.TH           as TH
+import qualified Luna.Package.Structure.Name   as Project
+import qualified LunaStudio.Data.GraphLocation as GraphLocation
+import qualified System.IO.Temp                as Temp
 
-import Control.Concurrent.MVar       (newEmptyMVar)
-import Control.Concurrent.STM        (atomically)
-import Control.Concurrent.STM.TChan  (newTChan)
-import Control.Exception             (bracket)
-import Data.Char                     (isSpace)
-import Data.List                     (dropWhileEnd)
-import Empire.Commands.Library       (createLibrary)
-import Empire.Data.Graph             (CommandState (CommandState),
-                                      defaultPMState)
-import Empire.Empire                 (CommunicationEnv (CommunicationEnv),
-                                      Empire, evalEmpire)
-import LunaStudio.Data.GraphLocation (GraphLocation (GraphLocation))
-import Test.Hspec                    (Expectation, Spec, SpecWith, around,
-                                      describe, parallel, shouldBe)
-import Text.RawString.QQ             (r)
+import Control.Concurrent.MVar         (newEmptyMVar)
+import Control.Concurrent.STM          (atomically)
+import Control.Concurrent.STM.TChan    (newTChan)
+import Control.Exception               (bracket, finally)
+import Data.Char                       (isSpace)
+import Data.List                       (dropWhileEnd)
+import Empire.ASTOp                    (runASTOp)
+import Empire.Commands.Library         (createLibrary, listLibraries,
+                                        withLibrary)
+import Empire.Data.Graph               (CommandState (CommandState),
+                                        defaultPMState)
+import Empire.Empire                   (CommunicationEnv (CommunicationEnv),
+                                        Empire, Env, evalEmpire, execEmpire,
+                                        runEmpire)
+import Empire.Empire                   (InterpreterEnv (InterpreterEnv))
+import Luna.Package.Structure.Generate (genPackageStructure)
+import LunaStudio.Data.GraphLocation   (GraphLocation (GraphLocation))
+import System.Directory                (canonicalizePath, getCurrentDirectory)
+import System.Environment              (lookupEnv, setEnv)
+import System.FilePath                 (takeDirectory, (</>))
+import Test.Hspec                      (Expectation, Spec, SpecWith, around,
+                                        describe, parallel, shouldBe)
+import Text.RawString.QQ               (r)
 
 
 withChannels :: (CommunicationEnv -> IO a) -> IO a
@@ -54,31 +70,34 @@ codeCheck :: Text -> (Text -> Expectation)
 codeCheck expectedCode = \resultCode ->
     Text.strip resultCode `shouldBe` normalizeLunaCode expectedCode
 
+noAction :: GraphLocation -> Empire ()
+noAction _ = pure ()
+
+evalEmpireWithDefaultState :: CommunicationEnv -> Empire a -> IO a
+evalEmpireWithDefaultState = fmap fst .: runEmpireWithDefaultState
+
+execEmpireWithDefaultState
+    :: CommunicationEnv -> Empire a -> IO (CommandState Env)
+execEmpireWithDefaultState = fmap snd .: runEmpireWithDefaultState
+
+runEmpireWithDefaultState
+    :: CommunicationEnv -> Empire a -> IO (a, CommandState Env)
+runEmpireWithDefaultState env action = defaultPMState >>= \pm ->
+    runEmpire env (CommandState pm def) action
+
+
 testCase
     :: Text
     -> Text
     -> (GraphLocation -> Empire a)
     -> CommunicationEnv
     -> Expectation
-testCase initialCode expectedCode action env = let
-        filePath = "/TestPath"
-        topGl    = GraphLocation filePath def
-        execute  = do
-            createLibrary Nothing filePath
-            Graph.loadCode topGl $ normalizeLunaCode initialCode
-            let mainNodeName = "main"
-                withMain mainNodeId = do
-                    let gl = topGl |>= mainNodeId
-                    mockNodesLayout gl
-                    pure gl
-            mainNodeId <- findNodeIdByName topGl mainNodeName
-            gl <- maybe (pure topGl) withMain mainNodeId
-            action gl
-            Graph.getCode gl
-    in do
-        pm         <- defaultPMState
-        resultCode <- evalEmpire env (CommandState pm def) execute
-        codeCheck expectedCode resultCode
+testCase initialCode expectedCode action env = do
+    resultCode <- evalEmpireWithDefaultState env $ do
+        gl <- prepareTestEnvironment initialCode
+        action gl
+        Graph.getCode gl
+    codeCheck expectedCode resultCode
 
 --[TODO]: This function is copy paste of testCase and is meant to be removed soon, when markers are removed from Luna
 testCaseWithMarkers
@@ -87,22 +106,101 @@ testCaseWithMarkers
     -> (GraphLocation -> Empire a)
     -> CommunicationEnv
     -> Expectation
-testCaseWithMarkers initialCode expectedCode action env = let
-        filePath = "/TestPath"
-        topGl    = GraphLocation filePath def
-        execute  = do
-            createLibrary Nothing filePath
-            Graph.loadCode topGl $ normalizeLunaCode initialCode
-            let mainNodeName = "main"
-                withMain mainNodeId = do
-                    let gl = topGl |>= mainNodeId
-                    mockNodesLayout gl
-                    pure gl
-            mainNodeId <- findNodeIdByName topGl mainNodeName
-            gl <- maybe (pure topGl) withMain mainNodeId
-            action gl
-            Graph.withGraph gl (use Graph.code)
-    in do
-        pm         <- defaultPMState
-        resultCode <- evalEmpire env (CommandState pm def) execute
+testCaseWithMarkers initialCode expectedCode action env = do
+    resultCode <- evalEmpireWithDefaultState env $ do
+        gl <- prepareTestEnvironment initialCode
+        action gl
+        Graph.withGraph gl (use Graph.code)
+    codeCheck expectedCode resultCode
+
+testCaseWithTC
+    :: Text
+    -> Text
+    -> (GraphLocation -> Empire a)
+    -> (GraphLocation -> Empire b)
+    -> CommunicationEnv
+    -> Expectation
+testCaseWithTC initialCode expectedCode action tcResultCheck env = let
+    projectParentDirName = "luna-test-hspec-empire-tc"
+    inTempDirectory = Temp.withSystemTempDirectory projectParentDirName
+    in inTempDirectory $ \projectParentDirNamePath -> do
+        ((gl, resultCode, clsGraph, rooted), state)
+            <- runEmpireWithDefaultState env $ do
+                gl <- prepareTestEnvironmentWithTC
+                    projectParentDirNamePath
+                    initialCode
+                let topGl = gl & GraphLocation.breadcrumb .~ def
+                action gl
+                code <- Graph.getCode gl
+                Graph.withUnit topGl $ do
+                    clsGraph <- use Graph.userState
+                    rooted <- runASTOp . Store.serializeWithRedirectMap
+                        $ clsGraph ^. Graph.clsClass
+                    pure (gl, code, clsGraph, rooted)
         codeCheck expectedCode resultCode
+        withMockedLunaRoot . void $ do
+            pmState <- Graph.defaultPMState
+            let commandState = CommandState pmState
+                    $ InterpreterEnv (pure ()) clsGraph mempty def def def def
+            updatedState <- execEmpire env commandState $
+                Typecheck.run gl clsGraph rooted False False
+            let updatedClsGraph
+                    = updatedState ^. Graph.userState . Empire.clsGraph
+            evalEmpire env state $ do
+                libPath <- fmap (view Library.path . head) listLibraries
+                withLibrary libPath
+                    $ Graph.userState . Library.body .= updatedClsGraph
+                tcResultCheck gl
+
+prepareTestEnvironment :: Text -> Empire GraphLocation
+prepareTestEnvironment = prepareTestEnvironmentWithCustomPath defProjectPath where
+    defProjectPath = "/TestProject"
+
+prepareTestEnvironmentWithTC :: FilePath -> Text -> Empire GraphLocation
+prepareTestEnvironmentWithTC projectParentDirName initialCode = let
+    projectName             = "TestProject"
+    genProjectPath dirPath  = dirPath </> projectName
+    srcDirName              = "src"
+    mainLunaName            = "Main.luna"
+    genMainLunaPath pkgPath = pkgPath </> srcDirName </> mainLunaName
+    in do
+        --[TODO]: Find out why lack of this line causes segmentation fault
+        createLibrary Nothing $ "/" <> projectName
+        Right pkgPath <- genPackageStructure
+            (genProjectPath projectParentDirName)
+            Nothing
+            def
+        prepareTestEnvironmentWithCustomPath
+            (genMainLunaPath pkgPath)
+            initialCode
+
+prepareTestEnvironmentWithCustomPath :: FilePath -> Text -> Empire GraphLocation
+prepareTestEnvironmentWithCustomPath filePath initialCode = let
+    topGl               = GraphLocation filePath def
+    mainNodeName        = "main"
+    withMain mainNodeId = do
+        let gl = topGl |>= mainNodeId
+        mockNodesLayout gl
+        pure gl
+    in do
+        createLibrary Nothing filePath
+        Graph.loadCode topGl $ normalizeLunaCode initialCode
+        mainNodeId <- findNodeIdByName topGl mainNodeName
+        maybe (pure topGl) withMain mainNodeId
+
+withMockedLunaRoot :: IO a -> IO a
+withMockedLunaRoot action = let
+    testSpecEmpireHsPath = $(do
+        dir      <- TH.runIO getCurrentDirectory
+        fileName <- TH.loc_filename <$> TH.location
+        TH.litE . TH.stringL $ dir </> fileName)
+    envDirName  = "env"
+    repoDirPath = takeDirectory testSpecEmpireHsPath </> "../../../../.."
+    envDirPath  = repoDirPath </> envDirName
+    in do
+        userLunaRoot   <- fromMaybe mempty <$> lookupEnv Project.lunaRootEnv
+        mockedLunaRoot <- canonicalizePath envDirPath
+        finally
+            (setEnv Project.lunaRootEnv mockedLunaRoot >> action)
+            $ setEnv Project.lunaRootEnv userLunaRoot
+            

--- a/libs/luna-empire/test/Test/Hspec/Empire.hs
+++ b/libs/luna-empire/test/Test/Hspec/Empire.hs
@@ -8,9 +8,9 @@ import Empire.Prelude
 import qualified Data.Graph.Store              as Store
 import qualified Data.Text                     as Text
 import qualified Empire.Commands.Graph         as Graph
-import qualified Empire.Commands.Typecheck     as Typecheck (runNoCleanUp)
+import qualified Empire.Commands.Typecheck     as Typecheck
 import qualified Empire.Data.Graph             as Graph
-import qualified Empire.Data.Library           as Library (body, path)
+import qualified Empire.Data.Library           as Library
 import qualified Empire.Empire                 as Empire
 import qualified LunaStudio.Data.GraphLocation as GraphLocation
 import qualified System.IO.Temp                as Temp
@@ -22,7 +22,7 @@ import Control.Exception               (bracket)
 import Data.Char                       (isSpace)
 import Data.List                       (dropWhileEnd)
 import Empire.ASTOp                    (runASTOp)
-import Empire.Commands.Library         (createLibrary, listLibraries,
+import Empire.Commands.Library         (createLibrary,
                                         withLibrary)
 import Empire.Data.Graph               (CommandState (CommandState),
                                         defaultPMState)
@@ -142,8 +142,7 @@ testCaseWithTC initialCode expectedCode action tcResultCheck env = let
         let updatedClsGraph
                 = updatedState ^. Graph.userState . Empire.clsGraph
         void . evalEmpire env state $ do
-            libPath <- fmap (view Library.path . head) listLibraries
-            withLibrary libPath
+            withLibrary (gl ^. GraphLocation.filePath)
                 $ Graph.userState . Library.body .= updatedClsGraph
             tcResultCheck gl
 

--- a/libs/luna-empire/test/Test/Typecheck/PatternMatchSpec.hs
+++ b/libs/luna-empire/test/Test/Typecheck/PatternMatchSpec.hs
@@ -1,0 +1,46 @@
+module Test.Typecheck.PatternMatchSpec (spec) where
+
+import Empire.Prelude
+
+import qualified LunaStudio.Data.Node as Node
+
+import LunaStudio.Data.LabeledTree    (LabeledTree (LabeledTree))
+import LunaStudio.Data.Port           (OutPortIndex (Projection),
+                                       OutPorts (OutPorts), Port (Port),
+                                       PortState (NotConnected))
+import LunaStudio.Data.TypeRep        (TypeRep (TStar))
+import Test.Hspec                     (Spec, describe, it)
+import Test.Hspec.Empire              (findNodeByName,
+                                       mkAllPort, noAction, runTests, testCaseWithTC)
+import Test.Hspec.Expectations.Lifted (shouldBe)
+import Text.RawString.QQ              (r)
+
+
+spec :: Spec
+spec = runTests "typechecker pattern match tests" $ do
+    describe "ports tests" $ do
+        it "contains proper ports for pattern match on custom class" $ let
+            code = [r|
+                import Std.Base
+
+                class Vector:
+                    x y z :: Int
+
+                def main:
+                    v = Vector 1 2 3
+                    Vector a b c = v
+                    None
+                |]
+            prepare gl = do
+                Just patternMatch <- findNodeByName gl "Vector a b c"
+                pure patternMatch
+            expectedPatternMatchOutPorts = LabeledTree
+                (OutPorts
+                    [ LabeledTree def $ Port [Projection 0] "a" TStar NotConnected
+                    , LabeledTree def $ Port [Projection 1] "b" TStar NotConnected
+                    , LabeledTree def $ Port [Projection 2] "c" TStar NotConnected ])
+                (mkAllPort "Vector a b c" NotConnected)
+            in testCaseWithTC code code noAction $ \gl -> do
+                patternMatch <- prepare gl
+                let patternMatchOutPorts = patternMatch ^. Node.outPorts
+                patternMatchOutPorts `shouldBe` expectedPatternMatchOutPorts

--- a/libs/luna-empire/test/Test/Typecheck/PatternMatchSpec.hs
+++ b/libs/luna-empire/test/Test/Typecheck/PatternMatchSpec.hs
@@ -8,10 +8,10 @@ import LunaStudio.Data.LabeledTree    (LabeledTree (LabeledTree))
 import LunaStudio.Data.Port           (OutPortIndex (Projection),
                                        OutPorts (OutPorts), Port (Port),
                                        PortState (NotConnected))
-import LunaStudio.Data.TypeRep        (TypeRep (TStar))
+import LunaStudio.Data.TypeRep        (TypeRep (TCons))
 import Test.Hspec                     (Spec, describe, it)
 import Test.Hspec.Empire              (findNodeByName,
-                                       mkAllPort, noAction, runTests, testCaseWithTC)
+                                       noAction, runTests, testCaseWithTC)
 import Test.Hspec.Expectations.Lifted (shouldBe)
 import Text.RawString.QQ              (r)
 
@@ -32,14 +32,14 @@ spec = runTests "typechecker pattern match tests" $ do
                     None
                 |]
             prepare gl = do
-                Just patternMatch <- findNodeByName gl "Vector a b c"
+                Just patternMatch <- findNodeByName gl "TestProject.Main.Vector.Vector a b c"
                 pure patternMatch
             expectedPatternMatchOutPorts = LabeledTree
                 (OutPorts
-                    [ LabeledTree def $ Port [Projection 0] "a" TStar NotConnected
-                    , LabeledTree def $ Port [Projection 1] "b" TStar NotConnected
-                    , LabeledTree def $ Port [Projection 2] "c" TStar NotConnected ])
-                (mkAllPort "Vector a b c" NotConnected)
+                    [ LabeledTree def $ Port [Projection 0] "a" (TCons "Int" mempty) NotConnected
+                    , LabeledTree def $ Port [Projection 1] "b" (TCons "Int" mempty) NotConnected
+                    , LabeledTree def $ Port [Projection 2] "c" (TCons "Int" mempty) NotConnected ])
+                (Port mempty "TestProject.Main.Vector.Vector a b c" (TCons "Vector" mempty) NotConnected)
             in testCaseWithTC code code noAction $ \gl -> do
                 patternMatch <- prepare gl
                 let patternMatchOutPorts = patternMatch ^. Node.outPorts


### PR DESCRIPTION
### Pull Request Description

This pull request fixes #1110 which turned out to be a problem with handling response from typechecker. Because I needed to introduce tests for this issue I've also provided with wrapper function for all preparations and execution that needs to be done to get results from TC.

### Important Notes

- Pattern match for custom data types works and shows correct ports.
- An easy to use testing function which fires TC is now available so testing should be easier.

### Checklist
Please include the following checklist in your PR:

- [  ] The documentation has been updated if necessary.
- [  ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [  ] The code has been tested where possible.

