### PR TITLE
Disable deprecation cop

### DIFF
--- a/config/config.cson
+++ b/config/config.cson
@@ -7,6 +7,7 @@
     automaticallyUpdate: false
     destroyEmptyPanes: true
     disabledPackages: [
+      "deprecation-cop"
       "dev-live-reload"
       "hidpi"
       "linter-ui-default"


### PR DESCRIPTION
### Pull Request Description

- Since we cannot fix warnings shown by deprecation-cop, as they refer to atom-core, we are disabling it

### Important Notes

- This is temporary solution

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

