### PR TITLE
Display "Press TAB to start" message when no nodes on scene

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -46,7 +46,7 @@ packages:
 - {location: ../../tools/batch/plugins/luna-empire}
 - {location: ../../tools/batch/plugins/request-monitor}
 - extra-dep: true
-  location: {commit: 6f1a6ebaaa4ffc6ec5b07fe19c170001f6e313eb, git: 'git@github.com:luna/luna.git'}
+  location: {commit: 8d2487fd4a7ca858878a1afe02d60fa8505c5b52, git: 'git@github.com:luna/luna.git'}
   subdirs:
     - core
     - syntax/text/parser2

--- a/luna-studio/node-editor-view/src/NodeEditor/React/View/NodeEditor.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/View/NodeEditor.hs
@@ -123,6 +123,7 @@ graph = React.defineView name $ \(ref, ne', isTopLevel) -> do
                 [ "className" $= Style.prefixFromList (["graph"] <> if allowVisualizations && isAnyVisActive then ["graph--has-visualization-active"] else [])
                 , "key"       $= "graph"
                 ] $ do
+                when (null nodes) $ div_ $ elemString $ "Press TAB to start"
 
                 dynamicStyles_ camera $ ne ^. NodeEditor.expressionNodesRecursive
 


### PR DESCRIPTION
### Pull Request Description

- This PR removes initial "Test me" node, added to empty project. Now, it is displaying "press TAB to start" message, when scene is empty

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

