### PR TITLE
Uses of vars visible as nodes

### DIFF
--- a/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
+++ b/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
@@ -44,13 +44,15 @@ getMarker marker = do
     matchExpr marker $ \case
         Marker index -> return index
 
-childrenFromSeq :: Delta -> EdgeRef -> GraphOp (Map NodeId BH.BChild)
-childrenFromSeq tgtBeg edge = do
+childrenFromSeq :: NodeRef -> Delta -> EdgeRef -> GraphOp (Map NodeId BH.BChild)
+childrenFromSeq currentFun tgtBeg edge = do
     ref <- source edge
     off <- Code.getOffsetRelativeToTarget edge
     let beg = tgtBeg + off
     matchExpr ref $ \case
-        Seq    l r    -> Map.union <$> (childrenFromSeq beg (coerce l)) <*> (lambdaChildren beg (coerce r))
+        Seq    l r    -> Map.union
+            <$> childrenFromSeq currentFun beg (coerce l)
+            <*> lambdaChildren  currentFun beg (coerce r)
         Marked m expr -> do
             expr'      <- source expr
             index      <- getMarker =<< source m
@@ -63,35 +65,49 @@ childrenFromSeq tgtBeg edge = do
                     source r
                 ASGFunction n _ b -> do
                     ASTBuilder.attachNodeMarkers uid [] =<< source n
-                    return expr'
+                    pure expr'
                 _ -> do
-                    putLayer @Marker expr' . Just =<< toPortMarker (OutPortRef (convert uid) [])
-                    return expr'
+                    putLayer @Marker expr' . Just
+                        =<< toPortMarker (OutPortRef (convert uid) [])
+                    pure expr'
             child    <- prepareChild ref childTarget
             nodeMeta <- use $ Graph.nodeCache . nodeMetaMap . at index
             forM nodeMeta $ AST.writeMeta ref
-            return $ Map.singleton uid child
-        Invalid{} -> return def
+            pure $ Map.singleton uid child
+        Invalid{} -> pure def
         _ -> do
             Code.addCodeMarker beg edge
-            childrenFromSeq tgtBeg edge
+            childrenFromSeq currentFun tgtBeg edge
 
-isNone :: NodeRef -> GraphOp Bool
-isNone = flip matchExpr $ \case
-    Cons n _ -> return $ n == "None"
-    _           -> return False
-
-lambdaChildren :: Delta -> EdgeRef -> GraphOp (Map NodeId BH.BChild)
-lambdaChildren tgtBeg edge = do
+lambdaChildren :: NodeRef -> Delta -> EdgeRef -> GraphOp (Map NodeId BH.BChild)
+lambdaChildren currentFun tgtBeg edge = do
     ref <- source edge
     off <- Code.getOffsetRelativeToTarget edge
     let beg = tgtBeg + off
     matchExpr ref $ \case
-        Seq l r -> Map.union <$> (childrenFromSeq beg (coerce l)) <*> (lambdaChildren beg (coerce r))
+        Seq l r -> Map.union
+            <$> childrenFromSeq currentFun beg (coerce l)
+            <*> lambdaChildren  currentFun beg (coerce r)
+        Var{}   -> do
+            output <- ASTRead.getLambdaOutputRef currentFun
+            if output == ref
+            then do
+                marker <- getLayer @Marker ref
+                if isJust marker
+                then pure Map.empty
+                else childrenFromSeq currentFun tgtBeg edge
+            else do
+                tgt    <- target edge
+                seq    <- ASTRead.isSeq tgt
+                if seq
+                then childrenFromSeq currentFun tgtBeg edge
+                else pure Map.empty
         _          -> do
             marker <- getLayer @Marker ref
-            isN    <- isNone ref
-            if isJust marker || isN then return Map.empty else childrenFromSeq tgtBeg edge
+            none   <- ASTRead.isNone ref
+            if isJust marker || none
+            then pure Map.empty
+            else childrenFromSeq currentFun tgtBeg edge
 
 prepareChild :: NodeRef -> NodeRef -> GraphOp BH.BChild
 prepareChild marked ref = go ref where
@@ -99,7 +115,7 @@ prepareChild marked ref = go ref where
         Lam {}         -> BH.LambdaChild <$> prepareLambdaChild   marked ref
         ASGFunction {} -> BH.LambdaChild <$> prepareFunctionChild marked ref
         Grouped g      -> go =<< source g
-        _                 -> prepareExprChild marked ref
+        _              -> prepareExprChild marked ref
 
 prepareChildWhenLambda :: NodeRef -> NodeRef -> GraphOp (Maybe BH.LamItem)
 prepareChildWhenLambda marked ref = do
@@ -113,7 +129,7 @@ prepareLambdaChild marked ref = do
     lambdaBody          <- source lambdaBodyLink
     Just lambdaCodeBeg  <- Code.getOffsetRelativeToFile =<< target lambdaBodyLink
     ASTBuilder.attachNodeMarkersForArgs (fst portMapping) [] ref
-    children            <- lambdaChildren lambdaCodeBeg lambdaBodyLink
+    children            <- lambdaChildren ref lambdaCodeBeg lambdaBodyLink
     newBody             <- ASTRead.getFirstNonLambdaRef ref
     return $ BH.LamItem portMapping marked children
 
@@ -127,7 +143,7 @@ prepareFunctionChild marked ref = do
     body         <- source bodyLink
     Just codeBeg <- Code.getOffsetRelativeToFile ref
     for_ (zip args [0..]) $ \(a, i) -> ASTBuilder.attachNodeMarkers (fst portMapping) [Port.Projection i] a
-    children <- lambdaChildren codeBeg bodyLink
+    children <- lambdaChildren marked codeBeg bodyLink
     newBody  <- ASTRead.getFirstNonLambdaRef ref
     return $ BH.LamItem portMapping marked children
 

--- a/libs/luna-empire/src/Empire/ASTOps/Read.hs
+++ b/libs/luna-empire/src/Empire/ASTOps/Read.hs
@@ -414,6 +414,16 @@ isRecord expr = match expr $ \case
     ClsASG{} -> return True
     _     -> return False
 
+isNone :: NodeRef -> GraphOp Bool
+isNone = flip matchExpr $ \case
+    Cons n _ -> return $ n == "None"
+    _        -> return False
+
+isSeq :: NodeRef -> GraphOp Bool
+isSeq = flip matchExpr $ \case
+    Seq{} -> return True
+    _     -> return False
+
 isAnonymous :: NodeRef -> GraphOp Bool
 isAnonymous expr = match expr $ \case
     Marked _ e -> isAnonymous =<< source e

--- a/libs/luna-empire/src/Empire/ASTOps/Read.hs
+++ b/libs/luna-empire/src/Empire/ASTOps/Read.hs
@@ -416,13 +416,13 @@ isRecord expr = match expr $ \case
 
 isNone :: NodeRef -> GraphOp Bool
 isNone = flip matchExpr $ \case
-    Cons n _ -> return $ n == "None"
-    _        -> return False
+    Cons n _ -> pure $ n == "None"
+    _        -> pure False
 
 isSeq :: NodeRef -> GraphOp Bool
 isSeq = flip matchExpr $ \case
-    Seq{} -> return True
-    _     -> return False
+    Seq{} -> pure True
+    _     -> pure False
 
 isAnonymous :: NodeRef -> GraphOp Bool
 isAnonymous expr = match expr $ \case

--- a/libs/luna-empire/src/Empire/Commands/Graph.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph.hs
@@ -77,7 +77,7 @@ import Debug
 import Empire.ASTOp                         (ClassOp, GraphOp,
                                              liftScheduler, runASTOp,
                                              runAliasAnalysis)
-import Empire.ASTOps.BreadcrumbHierarchy    (isNone, prepareChild)
+import Empire.ASTOps.BreadcrumbHierarchy    (prepareChild)
 import Empire.ASTOps.Parse                  (FunctionParsing (..))
 import Empire.Commands.Code                 (addExprMapping, getExprMap,
                                              getNextExprMarker, setExprMap)
@@ -390,7 +390,7 @@ putInSequence ref code meta = do
     blockEnd           <- Code.getCurrentBlockEnd
     currentOutput      <- getCurrentFunctionOutput
     anonOutput         <- ASTRead.isAnonymous currentOutput
-    none               <- isNone currentOutput
+    none               <- ASTRead.isNone currentOutput
     insertAfterAndUpdate oldSeq nearestNode ref blockEnd code
     when (Just currentOutput == nearestNode && anonOutput && not none) $ do
         Just nid <- GraphBuilder.getNodeIdWhenMarked currentOutput

--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -4,6 +4,7 @@ import Empire.Prelude hiding (range)
 
 import qualified Data.Map                      as Map
 import qualified Data.Text                     as Text
+import qualified Data.Text.IO                  as Text
 import qualified Empire.ASTOps.Parse           as ASTParse
 import qualified Empire.ASTOps.Read            as ASTRead
 import qualified Empire.Commands.Code          as Code

--- a/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
@@ -99,8 +99,8 @@ extractMarkedMetasAndIds root = matchExpr root $ \case
         expr    <- source e
         rest    <- extractMarkedMetasAndIds expr
         var     <- ASTRead.isVar expr
-        nidExpr <- ASTRead.getNodeId  expr
-        nidRoot <- ASTRead.getNodeId  root
+        nidExpr <- ASTRead.getNodeId expr
+        nidRoot <- ASTRead.getNodeId root
         let outId = if var then nidRoot else nidExpr <|> nidRoot
         pure $ (marker, (meta, outId)) : rest
     _ -> concat <$> (mapM (extractMarkedMetasAndIds <=< source) =<< inputs root)

--- a/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
@@ -94,13 +94,15 @@ extractMarkedMetasAndIds
     :: NodeRef -> ASTOp g [(Word64, (Maybe NodeMeta, Maybe NodeId))]
 extractMarkedMetasAndIds root = matchExpr root $ \case
     Marked m e -> do
-        meta   <- AST.readMeta root
-        marker <- getMarker =<< source m
-        expr   <- source e
-        rest   <- extractMarkedMetasAndIds expr
-        nid    <- ASTRead.getNodeId  expr
-        nid2   <- ASTRead.getNodeId  root
-        pure $ (marker, (meta, nid <|> nid2)) : rest
+        meta    <- AST.readMeta root
+        marker  <- getMarker =<< source m
+        expr    <- source e
+        rest    <- extractMarkedMetasAndIds expr
+        var     <- ASTRead.isVar expr
+        nidExpr <- ASTRead.getNodeId  expr
+        nidRoot <- ASTRead.getNodeId  root
+        let outId = if var then nidRoot else nidExpr <|> nidRoot
+        pure $ (marker, (meta, outId)) : rest
     _ -> concat <$> (mapM (extractMarkedMetasAndIds <=< source) =<< inputs root)
 
 stripMetadata :: Text -> Text

--- a/libs/luna-empire/test/Test/Graph/NodeVisibilitySpec.hs
+++ b/libs/luna-empire/test/Test/Graph/NodeVisibilitySpec.hs
@@ -90,5 +90,5 @@ spec = runTests "graph building" $ do
                 Graph.substituteCodeFromPoints file
                     [TextDiff (Just (Point 7 4, Point 7 4)) ".bar" Nothing]
                 (nodes, parseError) <- prepare loc
-                nodes `shouldSatisfy` (== 2) . length
+                nodes      `shouldSatisfy` (== 2) . length
                 parseError `shouldSatisfy` isNothing

--- a/libs/luna-empire/test/Test/Graph/NodeVisibilitySpec.hs
+++ b/libs/luna-empire/test/Test/Graph/NodeVisibilitySpec.hs
@@ -1,0 +1,88 @@
+module Test.Graph.NodeVisibilitySpec (spec) where
+
+import Empire.Prelude
+
+import qualified Empire.ASTOps.Read           as ASTRead
+import qualified Empire.Commands.Graph        as Graph
+import qualified Empire.Commands.GraphBuilder as GraphBuilder
+import qualified LunaStudio.Data.Graph        as Graph
+import qualified LunaStudio.Data.Node         as Node
+import qualified LunaStudio.Data.Port         as Port
+import qualified LunaStudio.Data.PortRef      as PortRef
+
+import Empire.ASTOp                   (runASTOp)
+import LunaStudio.Data.Connection     (Connection (Connection))
+import LunaStudio.Data.GraphLocation  (GraphLocation (GraphLocation), top)
+import LunaStudio.Data.LabeledTree    (LabeledTree (LabeledTree))
+import LunaStudio.Data.Point          (Point (Point))
+import LunaStudio.Data.Port           (InPortIndex (Arg), InPorts (InPorts),
+                                       OutPortIndex (Projection),
+                                       OutPorts (OutPorts), Port (Port),
+                                       PortState (Connected, NotConnected, WithDefault))
+import LunaStudio.Data.PortDefault    (PortDefault (Expression))
+import LunaStudio.Data.PortRef        (AnyPortRef (InPortRef', OutPortRef'))
+import LunaStudio.Data.TextDiff       (TextDiff (TextDiff))
+import LunaStudio.Data.TypeRep        (TypeRep (TStar))
+import Test.Hspec                     (Spec, describe, it)
+import Test.Hspec.Empire              (addNode, connectToInput,
+                                       emptyCodeTemplate, findNodeByName,
+                                       findNodeIdByName, inPortRef, mkAliasPort,
+                                       mkAllPort, mkSelfPort, outPortRef,
+                                       runTests, testCase, testCaseWithMarkers,
+                                       xitWithReason)
+import Test.Hspec.Expectations.Lifted (shouldBe, shouldSatisfy)
+import Text.RawString.QQ              (r)
+
+
+spec :: Spec
+spec = runTests "graph building" $ do    
+    describe "nodes visibility" $ do
+        it "shows use of variable as node" $ let
+            code = [r|
+                import Std.Base
+
+                def main:
+                    foo = 1
+                    foo
+                    None
+                |]
+            prepare gl = Graph.getNodes gl
+            in testCase code code $ \loc -> do
+                nodes <- prepare loc
+                nodes `shouldSatisfy` (== 2) . length
+        it "shows use of pattern matched variable as node" $ let
+            code = [r|
+                import Std.Base
+
+                def main:
+                    (a, b) = (1, 2)
+                    a
+                    None
+                |]
+            prepare gl = Graph.getNodes gl
+            in testCase code code $ \loc -> do
+                nodes <- prepare loc
+                nodes `shouldSatisfy` (== 2) . length
+        it "shows use of expression as node" $ let
+            code = [r|
+                import Std.Base
+
+                def main:
+                    foo = 1
+                    foo
+                    None
+                |]
+            expectedCode = [r|
+                import Std.Base
+
+                def main:
+                    foo = 1
+                    foo.bar
+                    None
+                |]
+            prepare gl = Graph.getNodes gl
+            in testCase code expectedCode $ \loc@(GraphLocation file _) -> do
+                Graph.substituteCodeFromPoints file
+                    [TextDiff (Just (Point 7 4, Point 7 4)) ".bar" Nothing]
+                nodes <- prepare loc
+                nodes `shouldSatisfy` (== 2) . length


### PR DESCRIPTION
### Pull Request Description

This pull request fixes visibility of nodes that reference variables defined beforehand. Consider code:
```
def main:
    foo = 1
    foo
    None
```
There was only one node visible, `foo = 1`, even though second use of `foo` should be visible too. This caused some strange issues like in #1098. Such problems should now be fixed, including variables bound by pattern matches.

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

