### PR TITLE
Reset previous error on new typecheck update

### DIFF
--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNode.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateNode.hs
@@ -113,7 +113,6 @@ localUpdateExpressionNode mods node
                 defVis          = if preventNodeMeta
                     then prevNode ^. ExpressionNode.defaultVisualizer
                     else node ^. ExpressionNode.defaultVisualizer
-                value = prevNode ^. ExpressionNode.value
                 n = node
                     & isSelected                       .~ selected
                     & ExpressionNode.mode              .~ mode'
@@ -123,7 +122,6 @@ localUpdateExpressionNode mods node
                     & ExpressionNode.visEnabled        .~ visEnabled
                     & ExpressionNode.defaultVisualizer .~ defVis
                     & ExpressionNode.errorVisEnabled   .~ errVis
-                    & ExpressionNode.value             .~ value
 
                 mayPortSelfId = find isSelf . map (view portId) $ inPortsList n
                 updatePortSelfMode n' selfPid m
@@ -168,7 +166,8 @@ localUpdateNodeTypecheck path update = do
                     & ExpressionNode.inPorts  .~ convert `fmap` inPorts
                     & ExpressionNode.outPorts .~ convert `fmap` outPorts
                     & ExpressionNode.value    %~ (\value ->
-                        if value == ExpressionNode.AwaitingTypecheck
+                        if  value == ExpressionNode.AwaitingTypecheck
+                            || ExpressionNode.returnsError node
                             then ExpressionNode.AwaitingData else value)
         API.OutputSidebarUpdate _ inPorts -> NodeEditor.modifyOutputNode nl $
             SidebarNode.outputSidebarPorts .= convert `fmap` inPorts


### PR DESCRIPTION
### Pull Request Description

This pull request fixes #1202 and probably #1124 (I was not able to reproduce the exact behaviour). These issues were caused by holding onto stale error in GUI and not refreshing it after a new typechecker update arrived. Because functions do not have visualizations, no results were sent that could replace previous errors on nodes.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

