### PR TITLE
Erroneous markers removal

### DIFF
--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -87,7 +87,7 @@ cumulativeOffsetStream tokens = tokens' where
 -- | Takes a pair of consecutive tokens and determines if a marker
 --   is placed in a proper position. If the second token is not a marker
 --   or if it seems to be correctly placed, `Nothing` is returned.
---   If marker is determined to be incorrectly placed, Just offset
+--   If marker is determined to be incorrectly placed, `Just offset`
 --   is returned, where offset is taken from the second token.
 --   This function assumes that Tokens have cumulative offset inside
 --   them, so offset returned is offset from the beginning of the code.

--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -1,6 +1,6 @@
 module Empire.Commands.Graph.Code where
 
-import Empire.Prelude hiding (range)
+import Empire.Prelude hiding (range, span)
 
 import qualified Data.Map                           as Map
 import qualified Data.Text                          as Text
@@ -13,7 +13,6 @@ import qualified Empire.Data.Library                as Library
 import qualified Empire.Data.FileMetadata           as FileMetadata
 import qualified Empire.Empire                      as Empire
 import qualified LunaStudio.Data.GraphLocation      as GraphLocation
-import qualified Luna.Syntax.Text.Analysis.SpanTree as SpanTree
 import qualified Luna.Syntax.Text.Lexer             as Lexer
 
 import Control.Monad.Catch                  (handle)
@@ -29,7 +28,6 @@ import Empire.Commands.Graph.Metadata       (markFunctions, prepareNodeCache,
                                              readMetadata', removeMetadataNode,
                                              stripMetadata)
 import Empire.Empire                        (Empire)
-import Luna.Syntax.Text.Analysis.SpanTree   (Spanned (Spanned))
 import Luna.Syntax.Text.Parser.State.Marker (TermMap (TermMap))
 import LunaStudio.Data.Breadcrumb           (Breadcrumb (Breadcrumb),
                                              BreadcrumbItem (Definition))
@@ -37,7 +35,6 @@ import LunaStudio.Data.GraphLocation        (GraphLocation)
 import LunaStudio.Data.NodeCache            (nodeIdMap, nodeMetaMap)
 import LunaStudio.Data.Point                (Point)
 import LunaStudio.Data.TextDiff             (TextDiff (TextDiff))
-import Debug.Trace
 
 substituteCodeFromPoints :: FilePath -> [TextDiff] -> Empire ()
 substituteCodeFromPoints path (breakDiffs -> diffs) = do

--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -86,7 +86,7 @@ cumulativeOffsetStream tokens = tokens' where
 
 -- | Takes a pair of consecutive tokens and determines if a marker
 --   is placed in a proper position. If the second token is not a marker
---   or if it seems to be correctly placed, Nothing is returned.
+--   or if it seems to be correctly placed, `Nothing` is returned.
 --   If marker is determined to be incorrectly placed, Just offset
 --   is returned, where offset is taken from the second token.
 --   This function assumes that Tokens have cumulative offset inside

--- a/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
+++ b/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
@@ -1,0 +1,94 @@
+module Test.Code.MarkerSanitizerSpec (spec) where
+
+import Empire.Prelude
+
+import qualified Empire.Commands.Graph        as Graph
+
+import Empire.Commands.Graph.Code     (sanitizeMarkers)
+import LunaStudio.Data.GraphLocation  (filePath, top)
+import LunaStudio.Data.Point          (Point (Point))
+import LunaStudio.Data.TextDiff       (TextDiff (TextDiff))
+import Test.Hspec                     (Spec, describe, it, shouldBe)
+import Test.Hspec.Empire              (normalizeLunaCode, testCaseWithMarkers)
+-- import Test.Hspec.Expectations.Lifted (shouldBe)
+import Text.RawString.QQ              (r)
+
+
+spec :: Spec
+spec = describe "sanitization" $ do
+    it "removes marker from accessor without spaces" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = foo«2».bar
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = foo.bar
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "removes marker from strings" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = "foo«2»bar"
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = "foobar"
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "removes marker from None" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                N«1»one
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "removes marker from accessor with spaces" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = foo «2». bar
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = foo . bar
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+        -- it "removes markers inside expressions" $ let
+        --     code = [r|
+        --         import Std.Base
+
+        --         «0»def main:
+        --             «1»node = foobar
+        --             None
+        --         |]
+        --     in testCaseWithMarkers code code $ \(view filePath -> file) -> do
+        --         Graph.substituteCodeFromPoints file
+        --             [TextDiff (Just (Point 14 3, Point 14 3)) "\n    " Nothing]
+        --         Graph.substituteCodeFromPoints file
+        --             [TextDiff (Just (Point 14 3, Point 4 4)) "" Nothing]
+        -- 


### PR DESCRIPTION
### Pull Request Description

After each substitute, we run `sanitizeMarkers` function on code, that attempts to remove markers that are incorrect, according to lexer output, or correct but their placement does not make sense in the context of code. Fixes #1087 and #448. 

If possible, please test before accepting. I've typed successfully TramsPlayground from scratch but I'd like to see more tests for this functionality.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

