### PR TITLE
Rename libraries to match new Luna hash

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -46,11 +46,11 @@ packages:
 - {location: ../../tools/batch/plugins/luna-empire}
 - {location: ../../tools/batch/plugins/request-monitor}
 - extra-dep: true
-  location: {commit: 588c2519b3bdcc75e43586256a707a3e3ddf8d19, git: 'git@github.com:luna/luna.git'}
+  location: {commit: 7a52acaffb0a7f57fbdc498f7e3279ada7ac89a8, git: 'git@github.com:luna/luna.git'}
   subdirs:
     - core
-    - syntax/text/parser2
-    - syntax/text/parser3
+    - syntax/text/parser
+    - syntax/text/builder
     - syntax/text/lexer
     - syntax/text/model
     - syntax/text/prettyprint

--- a/libs/luna-empire/package.yaml
+++ b/libs/luna-empire/package.yaml
@@ -73,8 +73,8 @@ dependencies:
     - luna-syntax-definition
     - luna-syntax-text-lexer
     - luna-syntax-text-model
-    - luna-syntax-text-parser2
-    - luna-syntax-text-parser3
+    - luna-syntax-text-parser
+    - luna-syntax-text-builder
     - luna-syntax-text-prettyprint
     - luna-text-processing
     - m-logger


### PR DESCRIPTION
### Pull Request Description
Renames `parser2` and `parser3` to match the new names in `luna`.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

