### PR TITLE
Restore previous expression on undoing new connection #1197

### DIFF
--- a/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
@@ -43,6 +43,7 @@ import           Empire.Commands.GraphBuilder            (buildClassGraph,
                                                           buildConnections,
                                                           buildGraph,
                                                           buildNodes,
+                                                          getNodeCode,
                                                           getNodeName)
 import qualified Empire.Commands.GraphUtils              as GraphUtils
 import           Empire.Data.AST                         (SomeASTException, astExceptionFromException,
@@ -330,10 +331,10 @@ handleAddConnection :: Request AddConnection.Request -> StateT Env BusT ()
 handleAddConnection = modifyGraph inverse action replyResult where
     getSrcPort = either id getSrcPortByNodeId
     getDstPort = either id getDstPortByNodeLoc
-    inverse (AddConnection.Request _ _ dst') = pure . AddConnection.Inverse $
-        case getDstPort dst' of
-            InPortRef'  portRef -> portRef
-            OutPortRef' portRef -> InPortRef (portRef ^. PortRef.nodeLoc) []
+    inverse (AddConnection.Request location _ dst') = do
+        let dstNodeId = either (view PortRef.nodeId) (view NodeLoc.nodeId) dst'
+        prevExpr <- Graph.withGraph location $ runASTOp $ getNodeCode dstNodeId
+        pure $ AddConnection.Inverse prevExpr
     action  (AddConnection.Request location src' dst')
         = withDefaultResult location $ Graph.connectCondTC
             True location (getSrcPort src') (getDstPort dst')

--- a/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
@@ -333,7 +333,7 @@ handleAddConnection = modifyGraph inverse action replyResult where
     getDstPort = either id getDstPortByNodeLoc
     inverse (AddConnection.Request location _ dst') = do
         let dstNodeId = either (view PortRef.nodeId) (view NodeLoc.nodeId) dst'
-        prevExpr <- Graph.withGraph location $ runASTOp $ getNodeCode dstNodeId
+        prevExpr <- Graph.withGraph location . runASTOp $ getNodeCode dstNodeId
         pure $ AddConnection.Inverse prevExpr
     action  (AddConnection.Request location src' dst')
         = withDefaultResult location $ Graph.connectCondTC

--- a/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
@@ -21,7 +21,7 @@ data Request = Request
     , _dst      :: Either AnyPortRef NodeLoc
     } deriving (Eq, Generic, Show)
 
-data Inverse = Inverse { _connId :: ConnectionId } deriving (Eq, Generic, Show)
+data Inverse = Inverse { _prevDstExpr :: Text } deriving (Eq, Generic, Show)
 
 makeLenses ''Request
 makeLenses ''Inverse

--- a/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
@@ -21,7 +21,9 @@ data Request = Request
     , _dst      :: Either AnyPortRef NodeLoc
     } deriving (Eq, Generic, Show)
 
-data Inverse = Inverse { _prevDestExpr :: Text } deriving (Eq, Generic, Show)
+data Inverse = Inverse
+    { _previousDestinationExpression :: Text
+    } deriving (Eq, Generic, Show)
 
 makeLenses ''Request
 makeLenses ''Inverse

--- a/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Graph/AddConnection.hs
@@ -21,7 +21,7 @@ data Request = Request
     , _dst      :: Either AnyPortRef NodeLoc
     } deriving (Eq, Generic, Show)
 
-data Inverse = Inverse { _prevDstExpr :: Text } deriving (Eq, Generic, Show)
+data Inverse = Inverse { _prevDestExpr :: Text } deriving (Eq, Generic, Show)
 
 makeLenses ''Request
 makeLenses ''Inverse


### PR DESCRIPTION
### Pull Request Description

Undo action for connect shouldn't be disconnect, but restore previous node expression. This was a bug discovered in #1197 

### Important Notes


### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

