### PR TITLE
Fix showing inline lambda as node argument #1223

### DIFF
--- a/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
+++ b/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
@@ -457,7 +457,7 @@ extractListPorts n = match n $ \case
         as <- mapM (source >=> extractListPorts) args'
         pure $ concat as
     _ -> do
-        pure []
+        pure mempty
 
 extractPortInfo :: NodeRef -> GraphOp [(TypeRep, PortState)]
 extractPortInfo n = do
@@ -490,7 +490,7 @@ buildArgPorts currentPort ref resolveFun = do
     typed <- extractPortInfo ref
     tp    <- getLayer @TypeLayer ref >>= source
     names <- match tp $ \case
-        ResolvedCons "Std.Base" "List" "List" _ -> pure []
+        ResolvedCons "Std.Base" "List" "List" _ -> pure mempty
         _                                       -> getPortsNames ref resolveFun
     let portsTypes = fmap fst typed
             <> List.replicate (length names - length typed) TStar

--- a/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
+++ b/libs/luna-empire/src/Empire/Commands/GraphBuilder.hs
@@ -27,7 +27,7 @@ import qualified LunaStudio.Data.NodeMeta             as NodeMeta
 import qualified LunaStudio.Data.Port                 as Port
 
 import Control.Lens                         (uses)
-import Control.Monad.State                  hiding (when)
+import Control.Monad.State                  hiding (void, when)
 import Data.Char                            (intToDigit)
 import Data.Foldable                        (toList)
 import Data.Maybe                           (catMaybes, maybeToList)
@@ -439,24 +439,25 @@ extractListPorts n = match n $ \case
                 argTp <- source edge >>= getLayer @TypeLayer >>= source
                 t     <- Print.getTypeRep argTp
                 ps    <- getPortState =<< source edge
-                return $ (t,ps) : rest
+                pure $ (t,ps) : rest
         source a >>= flip match (\case
-            Var _      -> addPort a
+            Var{}      -> addPort a
             IRNumber{} -> addPort a
             IRString{} -> addPort a
+            Lam{}      -> addPort a
             _ -> do
-                foo <- extractListPorts =<< source a
-                return $ foo <> rest)
+                portsInside <- extractListPorts =<< source a
+                pure $ portsInside <> rest)
     Lam i o -> do
         foo <- extractListPorts =<< source i
         bar <- extractListPorts =<< source o
-        return $ foo <> bar
+        pure $ foo <> bar
     ResolvedCons "Std.Base" "List" "Prepend" args -> do
         args' <- ptrListToList args
         as <- mapM (source >=> extractListPorts) args'
-        return $ concat as
+        pure $ concat as
     _ -> do
-        return []
+        pure []
 
 extractPortInfo :: NodeRef -> GraphOp [(TypeRep, PortState)]
 extractPortInfo n = do
@@ -489,7 +490,7 @@ buildArgPorts currentPort ref resolveFun = do
     typed <- extractPortInfo ref
     tp    <- getLayer @TypeLayer ref >>= source
     names <- match tp $ \case
-        ResolvedCons "Std.Base" "List" "List" _ -> return []
+        ResolvedCons "Std.Base" "List" "List" _ -> pure []
         _                                       -> getPortsNames ref resolveFun
     let portsTypes = fmap fst typed
             <> List.replicate (length names - length typed) TStar

--- a/libs/luna-empire/test/Test/Graph/ConnectionsSpec.hs
+++ b/libs/luna-empire/test/Test/Graph/ConnectionsSpec.hs
@@ -4,13 +4,19 @@ import Empire.Prelude
 
 import qualified Empire.Commands.Graph        as Graph
 import qualified Empire.Commands.GraphBuilder as GraphBuilder
+import qualified LunaStudio.Data.Node         as Node
 
 import Empire.ASTOp                   (runASTOp)
-import LunaStudio.Data.Port           (InPortIndex (Arg, Self))
+import LunaStudio.Data.Port           (InPortIndex (Arg, Self), InPorts (InPorts),
+                                       LabeledTree (LabeledTree), Port (Port),
+                                       PortState (WithDefault))
+import LunaStudio.Data.TypeRep        (TypeRep (TCons, TLam, TVar))
+import LunaStudio.Data.PortDefault    (PortDefault (Expression))
 import Test.Hspec                     (Spec, it)
-import Test.Hspec.Empire              (findNodeIdByName, inPortRef, outPortRef,
-                                       runTests, testCase)
-import Test.Hspec.Expectations.Lifted (shouldMatchList)
+import Test.Hspec.Empire              (findNodeByName, findNodeIdByName,
+                                       inPortRef, noAction, outPortRef,
+                                       runTests, testCase, testCaseWithTC)
+import Test.Hspec.Expectations.Lifted (shouldBe, shouldMatchList)
 import Text.RawString.QQ              (r)
 
 spec :: Spec
@@ -70,4 +76,41 @@ spec = runTests "connections tests" $ do
         in testCase code code $ \gl -> do
             (list1Id, nodeId, headId, connections) <- prepare gl
             connections `shouldMatchList` expectedConnections list1Id nodeId headId
-
+    it "shows port on List.filter with inline lambda after typechecking" $ let
+        code = [r|
+            def main:
+                node = [].filter (x: True)
+                None
+            |]
+        aliasPort = Port
+            mempty
+            "alias"
+            (TCons "List" [TVar "a"])
+            (WithDefault
+                (Expression
+                    "Std.Base.List.Empty . filter x: \171\&2\187\&Std.Base.Bool.True"
+                )
+            )
+        selfPort  = Port
+            [Self]
+            "self"
+            (TCons "List" [TVar "a"])
+            (WithDefault (Expression "Std.Base.List.Empty"))
+        argPort   = Port
+            [Arg 0]
+            "arg0"
+            (TLam (TVar "a") (TCons "Bool" []))
+            (WithDefault (Expression "x: \171\&2\187\&Std.Base.Bool.True"))
+        expectedOutPorts = LabeledTree
+            (InPorts
+                (Just (LabeledTree def selfPort))
+                Nothing
+                [LabeledTree def argPort])
+            aliasPort
+        nodeName = "node"
+        prepare gl = do
+            Just node <- findNodeByName gl nodeName
+            pure $ node ^. Node.inPorts
+        in testCaseWithTC code code noAction $ \gl -> do
+            inPorts <- prepare gl
+            inPorts `shouldBe` expectedOutPorts


### PR DESCRIPTION
### Pull Request Description

In code like `[1,2,3].filter (x: x == 1)`, filter did not have any input argument despite clearly taking lambda as an argument.

### Important Notes


### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

