### PR TITLE
Reverse y-axis in graph navigation. #912

### DIFF
--- a/luna-studio/node-editor/src/NodeEditor/Handler/Navigation.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Navigation.hs
@@ -108,8 +108,8 @@ closenestPow = 2.5
 axisDistanceRight, axisDistanceLeft, axisDistanceDown, axisDistanceUp :: Position -> Double
 axisDistanceRight pos =   pos ^. x
 axisDistanceLeft  pos = -(pos ^. x)
-axisDistanceDown  pos =   pos ^. y
-axisDistanceUp    pos = -(pos ^. y)
+axisDistanceDown  pos = -(pos ^. y)
+axisDistanceUp    pos =   pos ^. y
 
 findNearestRight, findNearestLeft, findNearestDown, findNearestUp :: Position -> [ExpressionNode] -> ExpressionNode
 findNearestRight pos = maximumBy (compare `on` closenest pos axisDistanceRight)
@@ -150,14 +150,14 @@ goCone findMost findNodesInCone findNodesOnSide = do
 findRightMost, findLeftMost, findDownMost, findUpMost :: [ExpressionNode] -> ExpressionNode
 findRightMost = maximumBy (compare `on` (^. position . x))
 findLeftMost  = minimumBy (compare `on` (^. position . x))
-findDownMost  = maximumBy (compare `on` (^. position . y))
-findUpMost    = minimumBy (compare `on` (^. position . y))
+findDownMost  = minimumBy (compare `on` (^. position . y))
+findUpMost    = maximumBy (compare `on` (^. position . y))
 
 findNodesOnRightSide, findNodesOnLeftSide, findNodesOnDownSide, findNodesOnUpSide :: Position -> [ExpressionNode] -> [ExpressionNode]
 findNodesOnRightSide pos = filter $ \node -> node ^. position . x > pos ^. x
 findNodesOnLeftSide  pos = filter $ \node -> node ^. position . x < pos ^. x
-findNodesOnDownSide  pos = filter $ \node -> node ^. position . y > pos ^. y
-findNodesOnUpSide    pos = filter $ \node -> node ^. position . y < pos ^. y
+findNodesOnDownSide  pos = filter $ \node -> node ^. position . y < pos ^. y
+findNodesOnUpSide    pos = filter $ \node -> node ^. position . y > pos ^. y
 
 findNodesOnRight, findNodesOnLeft, findNodesOnDown, findNodesOnUp :: Position -> [ExpressionNode] -> [ExpressionNode]
 findNodesOnRight = filter . isOnRight
@@ -168,8 +168,8 @@ findNodesOnUp    = filter . isOnUp
 isOnRight, isOnLeft, isOnDown, isOnUp :: Position -> ExpressionNode -> Bool
 isOnRight = isInCone (>)  skip (>=)
 isOnLeft  = isInCone (<)  skip (>=)
-isOnDown  = isInCone skip (>)  (<)
-isOnUp    = isInCone skip (<)  (<)
+isOnDown  = isInCone skip (<)  (<)
+isOnUp    = isInCone skip (>)  (<)
 
 skip :: Double -> Double -> Bool
 skip _ _ = True


### PR DESCRIPTION
### Pull Request Description

- As new gui has reversed y axis, we need also to reverse graph navigation using keyboard shortcuts

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

