### PR TITLE
Add native key bindings for visualizations #1126

### DIFF
--- a/luna-studio/atom/keymaps/luna-studio.cson
+++ b/luna-studio/atom/keymaps/luna-studio.cson
@@ -36,8 +36,6 @@
   'h'               : 'native!'
   'l'               : 'native!'
   'left'            : 'native!'
-  'left'            : 'native!'
-  'right'           : 'native!'
   'right'           : 'native!'
   'shift-backspace' : 'native!'
   'shift-down'      : 'native!'
@@ -48,6 +46,24 @@
   'up'              : 'native!'
   'enter'           : 'core:accept'
   'escape'          : 'core:cancel'
+
+'.luna-visualization--active':
+  'down'            : 'native!'
+  'left'            : 'native!'
+  'right'           : 'native!'
+  'up'              : 'native!'
+  'shift-down'      : 'native!'
+  'shift-left'      : 'native!'
+  'shift-right'     : 'native!'
+  'shift-up'        : 'native!'
+  'cmd-a'           : 'native!'
+  'cmd-c'           : 'native!'
+  'cmd-x'           : 'native!'
+  'cmd-v'           : 'native!'
+  'ctrl-a'          : 'native!'
+  'ctrl-c'          : 'native!'
+  'ctrl-x'          : 'native!'
+  'ctrl-v'          : 'native!'
 
 '.luna-searcher__input':
   'ctrl-0'     : 'luna-studio:searcher-accept-0'              # Searcher HintShortcut 0

--- a/luna-studio/node-editor-view/src/NodeEditor/React/View/Visualization.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/View/Visualization.hs
@@ -67,7 +67,7 @@ nodeVisualization = React.defineView objNameVis $ \(ref, visLibPaths, visProp, i
     withJust mayVisLibPath $ \visLibPath -> div_
         [ "key"       $= visKey vis
         , "id"        $= (nodePrefix <> fromString (show nid))
-        , "className" $= Style.prefixFromList (classes <> activeClass <> nSelectedClass )
+        , "className" $= ("native-key-bindings " <> Style.prefixFromList (classes <> activeClass <> nSelectedClass ))
         , "style"     @= Aeson.object [ "transform" Aeson..= ("translate(-150px," <> visShift <> "rem)"::String) ]
         , onDoubleClick $ \e _ -> [stopPropagation e]
         ] $
@@ -89,7 +89,7 @@ docVisualization = React.defineView docViewName $ \(ref, docPresent, visLibPath,
         classes      = "searcher__doc" : visibleClass <> fsModeClass <> activeClass
     div_
         [ "key"       $= "doc"
-        , "className" $= Style.prefixFromList classes
+        , "className" $= ("native-key-bindings " <> Style.prefixFromList classes)
         ] $ visualization_ ref visLibPath Searcher vis docPresent
 
 


### PR DESCRIPTION
### Pull Request Description

This PR enables following shortcuts for visualizations
- clipboard interactions: (ctrl/cmd-c, ctrl/cmd-x, ctrl/cmd-v)
- select (ctrl/cmd-a, shift + arrows)
- cursor movement (arrows)

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

