### PR TITLE
Fix markers removal for multiline expressions

### DIFF
--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -87,7 +87,7 @@ cumulativeOffsetStream tokens = scanl1 f tokens where
 
 indentFromOffsets :: Delta -> Delta -> Delta
 indentFromOffsets prevOffset nextOffset =
-    let eolSpan = 1
+    let eolSpan = length "\n"
     in nextOffset - prevOffset - eolSpan
 
 -- | Takes a pair of consecutive tokens and determines if a marker

--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -134,9 +134,10 @@ determineIndentation (blockIndent, _) tokens
             _         ->
                 let eolSpan = 1
                     indent = nextOffset - precOffset - eolSpan
-                in if indent > blockIndent
-                    then (blockIndent, tokens)
-                    else (indent, tokens)
+                in if indent == 0 then (blockIndent, tokens)
+                    else if indent > blockIndent
+                        then (blockIndent, tokens)
+                        else (indent, tokens)
     | otherwise = (blockIndent, tokens)
 
 

--- a/libs/luna-empire/test/FileModuleSpec.hs
+++ b/libs/luna-empire/test/FileModuleSpec.hs
@@ -30,6 +30,7 @@ import           LunaStudio.Data.GraphLocation   (GraphLocation (..), (|>=), (|>
 import qualified LunaStudio.Data.Node            as Node
 import           LunaStudio.Data.NodeMeta        (NodeMeta (..))
 import qualified LunaStudio.Data.NodeMeta        as NodeMeta
+import           LunaStudio.Data.Point           (Point (..))
 import           LunaStudio.Data.Port            (Port (..), PortState (..))
 import qualified LunaStudio.Data.Port            as Port
 import           LunaStudio.Data.PortDefault     (PortDefault (..))
@@ -37,6 +38,7 @@ import           LunaStudio.Data.PortRef         (AnyPortRef (..))
 import qualified LunaStudio.Data.PortRef         as PortRef
 import qualified LunaStudio.Data.Position        as Position
 import           LunaStudio.Data.Range           (Range (..))
+import           LunaStudio.Data.TextDiff        (TextDiff (..))
 import           LunaStudio.Data.TypeRep         (TypeRep (TStar))
 
 import           Empire.Empire
@@ -980,7 +982,6 @@ spec = around withChannels $ parallel $ do
             in specifyCodeChange initialCode expectedCode $ \loc@(GraphLocation file _) -> do
                 clipboard <- Graph.copyText loc [Range 14 25]
                 Graph.paste loc (Position.fromTuple (300, 0)) $ Text.unpack clipboard
-                Graph.substituteCode file [(32, 32, "    ")]
         it "pastes multiline code from text editor to node editor" $
             let initialCode = [r|
                     def main:
@@ -999,7 +1000,7 @@ spec = around withChannels $ parallel $ do
             in specifyCodeChange initialCode expectedCode $ \loc@(GraphLocation file _) -> do
                 clipboard <- Graph.copyText loc [Range 14 36]
                 Graph.paste loc (Position.fromTuple (1000, 0)) $ Text.unpack clipboard
-                Graph.substituteCode file [(46, 46, "    ")]
+                Graph.substituteCodeFromPoints file [TextDiff (Just (Point 4 4, Point 8 4)) "" Nothing]
         it "pastes multiline code from text editor to node editor at the beginning" $
             let initialCode = [r|
                     def main:

--- a/libs/luna-empire/test/MetadataSpec.hs
+++ b/libs/luna-empire/test/MetadataSpec.hs
@@ -254,7 +254,6 @@ spec = around withChannels $ parallel $ do
                     mapM Graph.getNodeIdForMarker [2,3]
                 Graph.prepareCopy (loc |>= main ^. Node.nodeId) [c, bar]
             code `shouldStartWith` [r|c = 4.0
-
 bar = foo 8.0 c|]
         it "copies lambda with metadata" $ \env -> do
             code <- evalEmp env $ do
@@ -425,8 +424,7 @@ def bar:
                 nodes <- Graph.getNodes loc
                 let Just main = find (\n -> n ^. Node.name == Just "main") nodes
                 Graph.paste (loc |>= main ^. Node.nodeId) (Position.fromTuple (200,0)) [r|c = 4.0
-    bar = foo 8.0 c|]
-                Graph.substituteCode "TestPath" [(30, 30, "    ")]
+bar = foo 8.0 c|]
                 nodes <- Graph.getNodes (loc |>= main ^. Node.nodeId)
                 code  <- Graph.withUnit loc $ use Graph.code
                 return (nodes, Text.unpack code)
@@ -434,7 +432,7 @@ def bar:
                 bar = find (\n -> n ^. Node.name == Just "bar") nodes
             c `shouldSatisfy` isJust
             bar `shouldSatisfy` isJust
-            code `shouldStartWith` [r|«1»def main:
+            code `shouldBe` [r|«1»def main:
     «0»pi = 3.14
     «2»c = 4.0
     «3»bar = foo 8.0 c
@@ -451,15 +449,13 @@ def bar:
                     (,) <$> Graph.getNodeIdForMarker 2 <*> Graph.getNodeIdForMarker 14
                 copy  <- Graph.prepareCopy (loc |>= main ^. Node.nodeId) [c, bar]
                 Graph.paste (loc |>= main ^. Node.nodeId) (Position.fromTuple (400,0)) copy
-                Graph.substituteCode "TestPath" [(225, 225, "    ")]
-                Graph.substituteCode "TestPath" [(242, 242, "    ")]
                 code  <- Graph.withUnit loc $ use Graph.code
                 (newC, newBar) <- Graph.withGraph (loc |>= main ^. Node.nodeId) $ runASTOp $ do
                     (Just c, Just bar) <- (,) <$> Graph.getNodeIdForMarker 19 <*> Graph.getNodeIdForMarker 20
                     (,) <$> GraphBuilder.buildNode c <*> GraphBuilder.buildNode bar
                 return (nodes, Text.unpack code, newC, newBar)
             newC ^. Node.nodeMeta . NodeMeta.position `shouldNotBe` newBar ^. Node.nodeMeta . NodeMeta.position
-            code `shouldStartWith` [r|«18»def main:
+            code `shouldBe` [r|«18»def main:
     «0»pi = 3.14
     «1»foo = a: b:
         «5»lala = 17.0
@@ -471,7 +467,6 @@ def bar:
         «11»m + n
     «2»c = 4.0
     «19»c = 4.0
-
     «20»bar = foo 8.0 c
 
     «14»bar = foo 8.0 c
@@ -499,21 +494,12 @@ def bar:
     «7»m = buzz b pi
     «8»m + n
 |]
-                Graph.substituteCode "TestPath" [ (141, 141, "    ")
-                                                , (123, 123, "    ")
-                                                , (103, 103, "    ")
-                                                , (89, 89, "    ")
-                                                , (75, 75, "    ")
-                                                , (58, 58, "    ")
-                                                , (42, 42, "    ")
-                                                , (30, 30, "    ")
-                                                ]
                 nodes <- Graph.getNodes (loc |>= main ^. Node.nodeId)
                 code  <- Graph.withUnit loc $ use Graph.code
                 return (nodes, Text.unpack code)
             let foo = find (\n -> n ^. Node.name == Just "foo") nodes
             foo `shouldSatisfy` isJust
-            code `shouldStartWith` [r|«1»def main:
+            code `shouldBe` [r|«1»def main:
     «0»pi = 3.14
     «2»foo = a: b:
         «3»lala = 17.0
@@ -523,7 +509,6 @@ def bar:
         «7»n = buzz a lala
         «8»m = buzz b pi
         «9»m + n
-
     None
 |]
         it "substitutes function body" $ \env -> do

--- a/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
+++ b/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
@@ -289,6 +289,70 @@ spec = parallel $ describe "sanitization" $ do
                 None
             |]
         in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "works on multiple functions with unindented expression" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+            «2»foo = 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+
+            «5»def quux:
+                «6»node = 1
+                «7»n = node + 4
+                n
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+            «2»foo = 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+
+            «5»def quux:
+                «6»node = 1
+                «7»n = node + 4
+                n
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "works on multiple functions with overindented expression" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+                    «2».+ 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+
+            «5»def quux:
+                «6»node = 1
+                «7»n = node + 4
+                n
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+                    .+ 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+
+            «5»def quux:
+                «6»node = 1
+                «7»n = node + 4
+                n
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
     it "works on empty string"  $ sanitizeMarkers ""       `shouldBe` ""
     it "works on single marker" $ sanitizeMarkers "«2»"    `shouldBe` "«2»"
     it "works on double marker" $ sanitizeMarkers "«2»«3»" `shouldBe` "«2»"

--- a/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
+++ b/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
@@ -197,6 +197,28 @@ spec = parallel $ describe "sanitization" $ do
                 None
             |]
         in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "leaves marker after unindented expression" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+            «2»foo = 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 1
+            «2»foo = 1
+                «3»bar = 1
+                «4»baz = 1
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
     it "leaves marker on two-line lambda" $ let
         initialCode = normalizeLunaCode [r|
             import Std.Base

--- a/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
+++ b/libs/luna-empire/test/Test/Code/MarkerSanitizerSpec.hs
@@ -161,6 +161,112 @@ spec = parallel $ describe "sanitization" $ do
                 None
             |]
         in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "removes marker on two-line broken expression" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 3
+                    «2».+ 2
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = 3
+                    .+ 2
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "leaves marker on one-line lambda" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x: «2»x.+ 2
+                «3»foo = 1
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x: «2»x.+ 2
+                «3»foo = 1
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "leaves marker on two-line lambda" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»x.+ 2
+                «3»foo = 1
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»x.+ 2
+                «3»foo = 1
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "leaves marker on multi-line lambda" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»c = x.+ 2
+                    «3»d = x.* 3
+                    «4»c + d
+                «5»foo = 1
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»c = x.+ 2
+                    «3»d = x.* 3
+                    «4»c + d
+                «5»foo = 1
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
+    it "removes marker on broken expression in multi-line lambda" $ let
+        initialCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»c = x.+ 2
+                    «3»d = x
+                        «5».* 3
+                    «4»c + d
+                «5»foo = 1
+                None
+            |]
+        expectedCode = normalizeLunaCode [r|
+            import Std.Base
+
+            «0»def main:
+                «1»node = x:
+                    «2»c = x.+ 2
+                    «3»d = x
+                        .* 3
+                    «4»c + d
+                «5»foo = 1
+                None
+            |]
+        in sanitizeMarkers initialCode `shouldBe` expectedCode
     it "works on empty string"  $ sanitizeMarkers ""       `shouldBe` ""
     it "works on single marker" $ sanitizeMarkers "«2»"    `shouldBe` "«2»"
     it "works on double marker" $ sanitizeMarkers "«2»«3»" `shouldBe` "«2»"


### PR DESCRIPTION
### Pull Request Description

Previously, each expression could only be defined in one line of code. New parser changed that behaviour to allowing multiline expressions, given that second and subsequent lines are more indented than the first one. This unveiled a bug when user could break an expression, causing second line to be markered and then indented it to keep code in one expression. 

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

