### PR TITLE
Bump entropy to the latest git version, containing my fix for #1262.

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -84,3 +84,5 @@ packages:
   location: {commit: ddfcd1e0372b93e947b380b911c123fe67227b21, git: 'git@github.com:luna/visualization-api.git'}
 - extra-dep: true
   location: {commit: 1fe94d4d8b106b2ab37c65de9200b3f0404ac2ca, git: 'git@github.com:luna/fuzzy-text.git'}
+- extra-dep: true
+  location: {commit: 4c71b554d738021b51723dbec6d1f1c823e73579, git: 'git@github.com:TomMD/entropy.git'}


### PR DESCRIPTION
### Pull Request Description
This PR adds `entropy` in latest git revision as extra-dep, so my fix is included. This fixes #1262 (at least for me).

### Important Notes
See #1262 and https://github.com/TomMD/entropy/pull/43 for further details.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

