### PR TITLE
Retry search nodes request on failure

### DIFF
--- a/luna-studio/node-editor/src/NodeEditor/Handler/Backend/Common.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Backend/Common.hs
@@ -1,34 +1,40 @@
-module NodeEditor.Handler.Backend.Common
-    ( whenOk
-    , handleResponse
-    , doNothing
-    , doNothing2
-    ) where
+module NodeEditor.Handler.Backend.Common where
 
-import           Common.Action.Command   (Command)
-import           Common.Debug            (measureResponseTime)
-import           Common.Prelude
-import           Common.Report           (error)
-import qualified Data.Text               as Text
-import qualified LunaStudio.API.Response as Response
-import qualified LunaStudio.API.Topic    as Topic
-import qualified LunaStudio.Data.Error   as ErrorAPI
-import           NodeEditor.Action.UUID  (isOwnRequest, unregisterRequest)
-import           NodeEditor.State.Global (State)
+import Common.Prelude
+
+import qualified Data.Text                    as Text
+import qualified LunaStudio.API.Graph.Request as Request
+import qualified LunaStudio.API.Response      as Response
+import qualified LunaStudio.API.Topic         as Topic
+import qualified LunaStudio.Data.Error        as ErrorAPI
+
+import Common.Action.Command               (Command)
+import Common.Batch.Connector.Connection   (BinaryRequest, Message (Message),
+                                            sendRequest)
+import Common.Debug                        (measureResponseTime)
+import Common.Report                       (error)
+import LunaStudio.API.Graph.Request        (GraphRequest)
+import LunaStudio.API.Request              (Request)
+import LunaStudio.Data.Error               (Error, LunaError)
+import NodeEditor.Action.Batch             (withWorkspace)
+import NodeEditor.Action.UUID              (isOwnRequest, unregisterRequest)
+import NodeEditor.Batch.Connector.Commands (withLibrary)
+import NodeEditor.State.Global             (State)
 
 
 whenOk :: Response.Response req inv res -> (res -> Command State ()) -> Command State ()
 whenOk (Response.Response _ _ _ _ (Response.Ok    res)) handler = handler res
 whenOk (Response.Response _ _ _ _ (Response.Error _  )) _       = return ()
 
-handleResponse :: (Topic.MessageTopic (Response.Response req inv res), Show req) => Response.Response req inv res -> (res -> Command State ()) -> (ErrorAPI.Error ErrorAPI.LunaError -> Response.Status inv -> Command State ()) -> Command State ()
-handleResponse resp@(Response.Response uuid _ _ inv res) success failure = do
+handleResponse :: (Topic.MessageTopic (Response.Response req inv res), Show req)
+    => Response.Response req inv res
+    -> (res -> Command State ())
+    -> (ErrorAPI.Error ErrorAPI.LunaError -> Response.Status inv -> Command State ())
+    -> Command State ()
+handleResponse resp@(Response.Response uuid _ req inv res) success failure = do
     case res of
         Response.Ok    res' -> success res'
-        Response.Error err  -> do
-            let str = Text.unpack $ err ^. ErrorAPI.errorContent
-            error $ str <> "\n\nwhile processing event\n\n" <> Topic.topic resp
-            failure err inv
+        Response.Error err  -> failure err inv
     measureResponseTime resp
     whenM (isOwnRequest uuid) $ unregisterRequest uuid
 
@@ -37,3 +43,17 @@ doNothing2 _ _ = return ()
 
 doNothing :: a -> Command State ()
 doNothing = const $ return ()
+
+logError :: Topic.MessageTopic (Response.Response req inv res)
+    => Response.Response req inv res -> Error LunaError -> Command State ()
+logError response err = error errStr where
+    str = Text.unpack $ err ^. ErrorAPI.errorContent
+    errStr = str <> "\n\nwhile processing event\n\n" <> Topic.topic response
+
+resend :: (BinaryRequest r, GraphRequest r, Topic.MessageTopic (Request r))
+    => r -> Command State ()
+resend r = withWorkspace resendRequest where
+    resendRequest workspace reqId guiId = sendRequest $ Message
+        reqId
+        guiId
+        . withLibrary workspace $ \gl -> r & Request.location .~ gl


### PR DESCRIPTION
### Pull Request Description

This is an attempt for working around #1254. Last issue there was caused by a particular sequence of actions:
1. Opening a new project
2. Start of a thread computing searcher hints that uses temporary Main.luna path from 1
3. Saving a project under different path
4. If computing searcher hints did not finish, there was a possibility that it tried to open now non-existent Main.luna file. In this case, it reported error to GUI and big red error popup appeared.

Now, in case of failure GUI will retry with currently opened file, namely Main.luna with proper new path.

### Important Notes

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

