### PR TITLE
More verbose logs on Windows

### DIFF
--- a/windows/s-luna-broker.xml
+++ b/windows/s-luna-broker.xml
@@ -6,6 +6,8 @@
   <executable>%BASE%\..\..\bin\private\luna-broker.exe</executable>
   <startmode>manual</startmode>
 
+  <arguments>-v5</arguments>
+
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
@@ -16,7 +18,7 @@
   <env name="LUNA_LIBS_PATH" value="%BASE%\..\env" />
   <env name="LUNA_STUDIO_LOG_PATH" value="%BASE%\..\logs" />
 
-  <logpath>%LUNA_STUDIO_LOG_PATH%</logpath>
+  <logpath>%BASE%\..\logs</logpath>
   <log mode="roll-by-size">
   </log>
 </configuration>

--- a/windows/s-luna-empire.xml
+++ b/windows/s-luna-empire.xml
@@ -6,6 +6,8 @@
   <executable>%BASE%\..\..\bin\private\luna-empire.exe</executable>
   <startmode>manual</startmode>
 
+  <arguments>-v5</arguments>
+
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
@@ -16,7 +18,7 @@
   <env name="LUNA_LIBS_PATH" value="%BASE%\..\env" />
   <env name="LUNA_STUDIO_LOG_PATH" value="%BASE%\..\logs" />
 
-  <logpath>%LUNA_STUDIO_LOG_PATH%</logpath>
+  <logpath>%BASE\..\logs</logpath>
   <log mode="roll-by-size">
   </log>
 </configuration>

--- a/windows/s-luna-undo-redo.xml
+++ b/windows/s-luna-undo-redo.xml
@@ -6,6 +6,8 @@
   <executable>%BASE%\..\..\bin\private\luna-undo-redo.exe</executable>
   <startmode>manual</startmode>
 
+  <arguments>-v5</arguments>
+
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
@@ -16,7 +18,7 @@
   <env name="LUNA_LIBS_PATH" value="%BASE%\..\env" />
   <env name="LUNA_STUDIO_LOG_PATH" value="%BASE%\..\logs" />
 
-  <logpath>%LUNA_STUDIO_LOG_PATH%</logpath>
+  <logpath>%BASE%\..\logs</logpath>
   <log mode="roll-by-size">
   </log>
 </configuration>

--- a/windows/s-luna-ws-connector.xml
+++ b/windows/s-luna-ws-connector.xml
@@ -6,6 +6,8 @@
   <executable>%BASE%\..\..\bin\private\luna-ws-connector.exe</executable>
   <startmode>manual</startmode>
 
+  <arguments>-v5</arguments>
+
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
   <onfailure action="restart" delay="1 sec"/>
@@ -16,7 +18,7 @@
   <env name="LUNA_LIBS_PATH" value="%BASE%\..\env" />
   <env name="LUNA_STUDIO_LOG_PATH" value="%BASE%\..\logs" />
 
-  <logpath>%LUNA_STUDIO_LOG_PATH%</logpath>
+  <logpath>%BASE%\..\logs</logpath>
   <log mode="roll-by-size">
   </log>
 </configuration>


### PR DESCRIPTION
### Pull Request Description

Passes `-v5` to all services on Windows. Also changes logging path of service wrappers to same as LUNA_STUDIO_LOG_PATH. Turns out, this environmental variable is not defined at the time of the path creation, so %LUNA_STUDIO_LOG_PATH% was put verbatim as directory name.

### Important Notes

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

