### PR TITLE
Do not destroy text editor when file is externally deleted (fixes bug on windows)

### DIFF
--- a/luna-studio/atom/lib/luna-code-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-code-editor-tab.coffee
@@ -49,8 +49,6 @@ TextBuffer::subscribeToFileOverride = (codeEditor) ->
         @emitter.emit 'did-delete'
         if modified
             @updateCachedDiskContents()
-        else
-            @destroy()
 
     @fileSubscriptions.add @file.onDidRename =>
         @emitter.emit 'did-change-path', @getPath()


### PR DESCRIPTION
### Pull Request Description

Safe save mechanism is moving original file as .backup, new file is saved and then moved to original file location. This mechanism triggers `did-delete` event on windows and editor panel is destroyed which has further consequences, causing https://github.com/luna/luna-studio/issues/1254

To fix this issue, we can
1. Remove delete detection of files by external program (not *luna-studio* itself), **which this PR implements**
1. do not safe save, or fix this mechanism to not trigger `did-delete` event, **this PR does NOT implements this**

### Important Notes

As described above, **this PR introduces new bug**: external deletion of files is not detected and gui is left then in wrong state (it is not working properly until file is manually closed)

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

