### PR TITLE
Fix incorrect searcher behaviour while editing name

### DIFF
--- a/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/Basic/UpdateSearcherHints.hs
@@ -27,9 +27,10 @@ import LunaStudio.Data.TypeRep            (ConstructorRep (ConstructorRep))
 import NodeEditor.Action.Batch            (searchNodes)
 import NodeEditor.Action.State.NodeEditor (getLocalFunctions, getSearcher,
                                            inTopLevelBreadcrumb, modifySearcher)
-import NodeEditor.React.Model.Searcher    (ClassName, LibrariesHintsMap, LibraryName,
-                                           Match, NodeSearcherData, Searcher,
-                                           Symbol, TypePreference, allCommands,
+import NodeEditor.React.Model.Searcher    (ClassName, LibrariesHintsMap,
+                                           LibraryName, Match, NodeSearcherData,
+                                           Searcher, Symbol, TypePreference,
+                                           allCommands,
                                            localFunctionsLibraryName)
 import NodeEditor.State.Global            (State)
 
@@ -113,7 +114,10 @@ localUpdateSearcherHints' = unlessM inTopLevelBreadcrumb $ do
             updateNodeSearcher s = do
                 let mayClassName = s ^? Searcher.modeData
                         . Searcher._ExpressionMode . Searcher.className . _Just
-                    hints input = search input nsData mayClassName
+                    hints input
+                        = if has (Searcher.modeData . Searcher._ExpressionMode) s
+                            then search input nsData mayClassName
+                            else mempty
                 s & Searcher.nodes .~ maybe mempty hints mayQuery
             updateMode (Searcher.CommandSearcher s)
                 = Searcher.CommandSearcher $ updateCommands s


### PR DESCRIPTION
### Pull Request Description

- The searcher was searching for hints using its data also during name change. Since our view does not display hints then it was hidden that first hint is always selected. With this fix, the searcher is not proposing anything when editing name so the problem should be solved.

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

