### PR TITLE
Undo transactions

### DIFF
--- a/libs/batch/plugins/luna-empire/package.yaml
+++ b/libs/batch/plugins/luna-empire/package.yaml
@@ -9,6 +9,7 @@ dependencies:
     - bimap
     - binary
     - bytestring
+    - constraints
     - containers
     - directory
     - either

--- a/libs/batch/plugins/luna-empire/src/Empire/Handlers.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Handlers.hs
@@ -33,14 +33,17 @@ import qualified LunaStudio.API.Graph.SetCode            as SetCode
 import qualified LunaStudio.API.Graph.SetNodeExpression  as SetNodeExpression
 import qualified LunaStudio.API.Graph.SetNodesMeta       as SetNodesMeta
 import qualified LunaStudio.API.Graph.SetPortDefault     as SetPortDefault
+import qualified LunaStudio.API.Graph.Transaction        as Transaction
 import qualified LunaStudio.API.Graph.TypeCheck          as TypeCheck
 
 import           Control.Monad.State   (StateT)
 import qualified Data.Binary           as Bin
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString.Lazy  as BSL
+import           Data.Constraint
 import           Data.Map.Strict       (Map)
 import qualified Data.Map.Strict       as Map
+import           Empire.ApiHandlers    (Modification)
 import           Empire.Env            (Env)
 import qualified Empire.Server.Atom    as Atom
 import qualified Empire.Server.Graph   as Graph
@@ -75,6 +78,7 @@ handlersMap = Map.fromList
     , makeHandler $ Server.handle @SetNodeExpression.Request
     , makeHandler $ Server.handle @SetNodesMeta.Request
     , makeHandler $ Server.handle @SetPortDefault.Request
+    , makeHandler $ Server.handle @Transaction.Request
     , makeHandler Graph.handleTypecheck
     , makeHandler $ Server.handle @Interpreter.Request
     , makeHandler Library.handleCreateLibrary
@@ -92,6 +96,7 @@ handlersMap = Map.fromList
     , makeHandler $ Server.handle @Substitute.Request
     , makeHandler $ Server.handleOk @SaveSettings.Request
     ]
+
 
 makeHandler :: forall a. (Topic.MessageTopic a, Bin.Binary a) => (a -> StateT Env BusT ()) -> (String, Handler)
 makeHandler h = (Topic.topic @a, process) where

--- a/libs/batch/plugins/luna-empire/src/Empire/Server.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server.hs
@@ -261,7 +261,6 @@ handleMessage = do
 defaultHandler :: ByteString -> StateT Env BusT ()
 defaultHandler content = do
     logger Logger.error $ "Not recognized request"
-    logger Logger.info $ unpack content
 
 handleRequest :: String -> String -> ByteString -> StateT Env BusT ()
 handleRequest logMsg topic content = do

--- a/libs/luna-empire/package.yaml
+++ b/libs/luna-empire/package.yaml
@@ -41,7 +41,9 @@ dependencies:
     - async
     - base
     - bimap
+    - binary
     - bytestring
+    - constraints
     - container
     - containers
     - convert

--- a/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
+++ b/libs/luna-empire/src/Empire/ASTOps/BreadcrumbHierarchy.hs
@@ -151,11 +151,11 @@ prepareExprChild marked ref = do
           _       -> par
     return $ BH.ExprChild $ foldl addItem bareItem $ zip [0..] items
 
-restorePortMappings :: Map (NodeId, Maybe Int) (NodeId, NodeId) -> GraphOp ()
-restorePortMappings previousPortMappings = do
+restorePortMappings :: NodeId -> Map (NodeId, Maybe Int) (NodeId, NodeId) -> GraphOp ()
+restorePortMappings funId previousPortMappings = do
     hierarchy <- use breadcrumbHierarchy
 
-    let goParent lamItem = goLamItem Nothing lamItem
+    let goParent lamItem = goLamItem (Just (funId, Nothing)) lamItem
 
         goBChild nodeId (BH.ExprChild exprItem)  = BH.ExprChild <$> goExprItem nodeId exprItem
         goBChild nodeId (BH.LambdaChild lamItem) = BH.LambdaChild <$> goLamItem (Just (nodeId, Nothing)) lamItem

--- a/libs/luna-empire/src/Empire/ApiHandlers.hs
+++ b/libs/luna-empire/src/Empire/ApiHandlers.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE PartialTypeSignatures #-}
+
 module Empire.ApiHandlers where
 
 import Prologue hiding (init, last)
@@ -46,12 +46,12 @@ import qualified LunaStudio.API.Graph.TypeCheck          as TypeCheck
 import qualified LunaStudio.API.Response                 as Response
 import qualified LunaStudio.API.Topic                    as Topic
 import qualified LunaStudio.Data.Breadcrumb              as Breadcrumb
-import qualified LunaStudio.Data.Connection       as Connection
+import qualified LunaStudio.Data.Connection              as Connection
 import qualified LunaStudio.Data.Graph                   as GraphAPI
 import qualified LunaStudio.Data.GraphLocation           as GraphLocation
-import qualified LunaStudio.Data.Node             as Node
+import qualified LunaStudio.Data.Node                    as Node
 import qualified LunaStudio.Data.NodeLoc                 as NodeLoc
-import qualified LunaStudio.Data.PortRef          as PortRef
+import qualified LunaStudio.Data.PortRef                 as PortRef
 import qualified LunaStudio.Data.Project                 as Project
 import qualified Path
 import qualified System.Log.MLogger                      as Logger
@@ -68,6 +68,7 @@ import Empire.ASTOp                  (runASTOp)
 import Empire.Commands.GraphBuilder  (buildClassGraph, buildConnections,
                                       buildGraph, buildNodes, getNodeCode,
                                       getNodeName)
+import Empire.Empire                 (Empire)
 import Empire.Data.AST               (SomeASTException,
                                       astExceptionFromException,
                                       astExceptionToException)
@@ -78,6 +79,7 @@ import LunaStudio.API.Response       (InverseOf, ResultOf)
 import LunaStudio.Data.Breadcrumb    (Breadcrumb (..))
 import LunaStudio.Data.Connection    (Connection (..))
 import LunaStudio.Data.Diff          (Diff, diff)
+import LunaStudio.Data.Graph         (Graph (Graph))
 import LunaStudio.Data.GraphLocation (GraphLocation (..))
 import LunaStudio.Data.NodeLoc       (NodeLoc (..))
 import LunaStudio.Data.PortRef       (InPortRef (..), OutPortRef (..), AnyPortRef (..))
@@ -87,9 +89,6 @@ import LunaStudio.Data.Port          (InPort (..), InPortIndex (..),
                                       Port (..), PortState (..), getPortNumber)
 import LunaStudio.Data.Project       (LocationSettings)
 
-import Empire.Empire         (Empire)
-import LunaStudio.Data.Graph (Graph (Graph))
-import qualified System.IO as IO
 
 type TransactionDict a =
         ( Modification a

--- a/libs/luna-empire/src/Empire/Commands/Graph.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph.hs
@@ -498,7 +498,7 @@ addPortNoTC loc (OutPortRef nl pid) name = runASTOp $ do
     let nid      = convert nl
         position = getPortNumber (pid)
     (inE, _) <- GraphBuilder.getEdgePortMapping
-    when (inE /= nid) $ throwM NotInputEdgeException
+    when (inE /= nid) $ throwM $ NotInputEdgeException inE nid
     ref <- ASTRead.getCurrentASTTarget
     ASTBuilder.detachNodeMarkersForArgs ref
     ids      <- uses Graph.breadcrumbHierarchy BH.topLevelIDs
@@ -647,7 +647,7 @@ removePort loc portRef = do
         ASTBuilder.detachNodeMarkersForArgs ref
         (inE, _) <- GraphBuilder.getEdgePortMapping
         if nodeId == inE then ASTModify.removeLambdaArg (portRef ^. PortRef.srcPortId) ref
-                         else throwM NotInputEdgeException
+                         else throwM $ NotInputEdgeException inE nodeId
         newLam <- ASTRead.getCurrentASTTarget
         ASTBuilder.attachNodeMarkersForArgs nodeId [] newLam
         GraphBuilder.buildInputSidebar nodeId
@@ -660,7 +660,7 @@ movePort loc portRef newPosition = do
         ref        <- ASTRead.getCurrentASTTarget
         (input, _) <- GraphBuilder.getEdgePortMapping
         if nodeId == input then ASTModify.moveLambdaArg (portRef ^. PortRef.srcPortId) newPosition ref
-                           else throwM NotInputEdgeException
+                           else throwM $ NotInputEdgeException input nodeId
         ref        <- ASTRead.getCurrentASTTarget
         ASTBuilder.attachNodeMarkersForArgs nodeId [] ref
         GraphBuilder.buildInputSidebar nodeId
@@ -673,7 +673,7 @@ renamePort loc portRef newName = do
         ref        <- ASTRead.getCurrentASTTarget
         (input, _) <- GraphBuilder.getEdgePortMapping
         if nodeId == input then ASTModify.renameLambdaArg (portRef ^. PortRef.srcPortId) (Text.unpack newName) ref
-                           else throwM NotInputEdgeException
+                           else throwM $ NotInputEdgeException input nodeId
         GraphBuilder.buildInputSidebar nodeId
     resendCode loc
 
@@ -688,7 +688,7 @@ getPortName loc portRef = do
         portsNames <- GraphBuilder.getPortsNames ref Nothing
         if nodeId == input
             then maybe (throwM $ PortDoesNotExistException portId) (return . convert) $ Safe.atMay portsNames arg
-            else throwM NotInputEdgeException
+            else throwM $ NotInputEdgeException input nodeId
 
 setNodeExpression :: GraphLocation -> NodeId -> Text -> Empire Node.Node
 setNodeExpression loc@(GraphLocation file _) nodeId expr' = do

--- a/libs/luna-empire/src/Empire/Commands/Graph/Breadcrumb.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Breadcrumb.hs
@@ -79,7 +79,7 @@ makeGraphCls fun lastUUID = do
         runAliasAnalysis
         runASTOp $ do
             ASTBreadcrumb.makeTopBreadcrumbHierarchy ref
-            ASTBreadcrumb.restorePortMappings (nodeCache ^. portMappingMap)
+            ASTBreadcrumb.restorePortMappings uuid (nodeCache ^. portMappingMap)
             use Graph.graphNodeCache
     Graph.userState . Graph.clsNodeCache .= updatedCache
     pure (uuid, graph)

--- a/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Metadata.hs
@@ -195,8 +195,10 @@ prepareNodeCache gl = do
     previousPortMappings
         <- forM funs $ \fun -> withGraph (toGraphLocation fun) $ runASTOp $ do
             hierarchy <- use Graph.breadcrumbHierarchy
+
             let lamItems = BH.getLamItems hierarchy
-                elems    = map lamItemToMapping lamItems
+                elems    = lamItemToMapping ((fun, Nothing), hierarchy)
+                            : map lamItemToMapping lamItems
             pure $ Map.fromList elems
     let previousNodeIds = Map.unions
             $ (Map.mapMaybe snd topMarkers)

--- a/libs/luna-empire/src/Empire/Data/AST.hs
+++ b/libs/luna-empire/src/Empire/Data/AST.hs
@@ -59,11 +59,19 @@ instance Exception InvalidConnectionException where
     toException   = astExceptionToException
     fromException = astExceptionFromException
 
-data NotInputEdgeException = NotInputEdgeException deriving (Show)
+data NotInputEdgeException = NotInputEdgeException {
+      _expected :: NodeId
+    , _received :: NodeId
+    } deriving (Show)
+
+makeLenses ''NotInputEdgeException
 
 instance Exception NotInputEdgeException where
     toException   = astExceptionToException
     fromException = astExceptionFromException
+    displayException e = "Exception: " <> show (e ^. received)
+                        <> " is not an input sidebar ID ("
+                        <> show (e ^. expected) <> ")"
 
 data PortDoesNotExistException = PortDoesNotExistException OutPortId deriving (Show)
 

--- a/libs/luna-empire/test/Test/Undo/InverseSpec.hs
+++ b/libs/luna-empire/test/Test/Undo/InverseSpec.hs
@@ -1,0 +1,102 @@
+module Test.Undo.InverseSpec where
+
+import Empire.Prelude
+
+import qualified Data.Binary                        as Binary
+import qualified Data.Map                           as Map
+import qualified Empire.Commands.Graph              as Graph
+import qualified LunaStudio.API.Graph.AddConnection as AddConnection
+import qualified LunaStudio.API.Graph.AddPort       as AddPort
+import qualified LunaStudio.API.Graph.SetNodesMeta  as SetNodesMeta
+import qualified LunaStudio.API.Graph.Transaction   as Transaction
+import qualified LunaStudio.API.Topic               as Topic
+import qualified LunaStudio.Data.Graph              as Graph
+import qualified LunaStudio.Data.Node               as Node
+import qualified LunaStudio.Data.NodeMeta           as NodeMeta
+import qualified LunaStudio.Data.Position           as Position
+
+import Empire.ApiHandlers             (perform, buildInverse)
+import LunaStudio.Data.NodeMeta       (NodeMeta(NodeMeta))
+import LunaStudio.Data.Port           (InPortIndex (Arg, Self),
+                                       OutPortIndex(Projection))
+import LunaStudio.Data.PortRef        (AnyPortRef (InPortRef'), InPortRef(..),
+                                       OutPortRef(..))
+import Test.Hspec                     (Spec, it)
+import Test.Hspec.Empire              (findNodeIdByName,
+                                       runTests, testCase)
+import Test.Hspec.Expectations.Lifted (shouldBe)
+import Text.RawString.QQ              (r)
+
+
+spec :: Spec
+spec = runTests "undo" $ do
+    it "should undo dropping node on connection" $ let
+        code = [r|
+            def main:
+                number1 = 3
+                negate1 = negate
+                expr1 = number1 +
+                None
+            |]
+        in testCase code code $ \gl -> do
+            graph        <- Graph.getGraph gl
+            Just number1 <- findNodeIdByName gl "number1"
+            Just expr1   <- findNodeIdByName gl "expr1"
+            Just negate1 <- findNodeIdByName gl "negate1"
+            connCenter <- do
+                metas <- Graph.getNodeMetas gl $ map convert [number1, expr1]
+                let [numberPos] = [ pos |
+                        Just (nid, (view NodeMeta.position -> pos)) <- metas,
+                        nid == convert number1 ]
+                let [exprPos] = [ pos |
+                        Just (nid, (view NodeMeta.position -> pos)) <- metas,
+                        nid == convert expr1 ]
+                return $ Position.averagePosition numberPos exprPos
+            let connLeftReq =
+                    AddConnection.Request
+                        gl
+                        (Left $ OutPortRef (convert number1) [])
+                        (Left $ InPortRef' $ InPortRef (convert negate1) [Self])
+                connRightReq =
+                    AddConnection.Request
+                        gl
+                        (Left $ OutPortRef (convert negate1) [])
+                        (Left $ InPortRef' $ InPortRef (convert expr1) [Arg 0])
+                moveNodeReq =
+                    SetNodesMeta.Request
+                        gl
+                        (Map.singleton negate1 (NodeMeta connCenter False Nothing))
+                mkReq req = (Topic.topic' req, Binary.encode req)
+                transaction = Transaction.Request gl [
+                        mkReq connLeftReq
+                      , mkReq connRightReq
+                      , mkReq moveNodeReq
+                      ]
+            inv <- buildInverse transaction
+            perform transaction
+            perform inv
+            graph' <- Graph.getGraph gl
+            graph' `shouldBe` graph
+    it "should undo adding port with connection" $ let
+        code = [r|
+            def main:
+                negate1 = negate
+                None
+            |]
+        in testCase code code $ \gl -> do
+            graph        <- Graph.getGraph gl
+            Just negate1 <- findNodeIdByName gl "negate1"
+            let Just inputSidebar =
+                   convert (graph ^? Graph.inputSidebar . _Just . Node.nodeId)
+                addPortReq =
+                    AddPort.Request
+                        gl
+                        (OutPortRef inputSidebar [Projection 0])
+                        [InPortRef' $ InPortRef (convert negate1) [Self]]
+                        (Just "a")
+            inv <- buildInverse addPortReq
+            perform addPortReq
+            perform inv
+            graph' <- Graph.getGraph gl
+            graph' `shouldBe` graph
+

--- a/libs/luna-studio-common/src/LunaStudio/API/Graph/Transaction.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Graph/Transaction.hs
@@ -1,0 +1,30 @@
+module LunaStudio.API.Graph.Transaction where
+
+import           Data.Aeson.Types              (ToJSON)
+import           Data.Binary                   (Binary)
+import           Data.ByteString.Lazy          (ByteString)
+import qualified LunaStudio.API.Graph.Request  as G
+import qualified LunaStudio.API.Request        as R
+import qualified LunaStudio.API.Topic          as T
+import           LunaStudio.Data.Diff          (Diff)
+import           LunaStudio.Data.GraphLocation (GraphLocation)
+import           LunaStudio.Data.PortDefault   (PortDefault)
+import           LunaStudio.Data.PortRef       (InPortRef)
+import           Prologue
+
+
+data Request = Request
+    { _location     :: GraphLocation
+    , _actions      :: [(T.Topic, ByteString)]
+    } deriving (Eq, Generic, Show)
+
+makeLenses ''Request
+
+instance Binary Request
+instance NFData Request
+-- instance ToJSON Request
+instance G.GraphRequest Request where location = location
+
+
+instance T.MessageTopic Request where
+    topic = "empire.graph.node.transaction"

--- a/libs/luna-studio-common/src/LunaStudio/API/Response.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Response.hs
@@ -31,6 +31,7 @@ import qualified LunaStudio.API.Graph.SetCode            as SetCode
 import qualified LunaStudio.API.Graph.SetNodeExpression  as SetNodeExpression
 import qualified LunaStudio.API.Graph.SetNodesMeta       as SetNodesMeta
 import qualified LunaStudio.API.Graph.SetPortDefault     as SetPortDefault
+import qualified LunaStudio.API.Graph.Transaction        as Transaction
 import qualified LunaStudio.API.Graph.TypeCheck          as TypeCheck
 
 import qualified LunaStudio.API.Topic                    as Topic
@@ -117,7 +118,7 @@ type instance ResultOf  AddImports.Request = Diff
 type instance InverseOf AddNode.Request = RemoveNodes.Request
 type instance ResultOf  AddNode.Request = Diff
 
-type instance InverseOf AddPort.Request = RemovePort.Request
+type instance InverseOf AddPort.Request = Transaction.Request
 type instance ResultOf  AddPort.Request = Diff
 
 type instance InverseOf AddSubgraph.Request = RemoveNodes.Request
@@ -188,6 +189,9 @@ type instance ResultOf  SetPortDefault.Request = Diff
 
 type instance InverseOf Substitute.Request = ()
 type instance ResultOf  Substitute.Request = Diff
+
+type instance InverseOf Transaction.Request = Transaction.Request
+type instance ResultOf  Transaction.Request = Diff
 
 type instance InverseOf TypeCheck.Request = ()
 type instance ResultOf  TypeCheck.Request = ()

--- a/libs/undo-redo/src/Handlers.hs
+++ b/libs/undo-redo/src/Handlers.hs
@@ -37,6 +37,7 @@ import qualified LunaStudio.API.Graph.SetCode            as SetCode
 import qualified LunaStudio.API.Graph.SetNodeExpression  as SetNodeExpression
 import qualified LunaStudio.API.Graph.SetNodesMeta       as SetNodesMeta
 import qualified LunaStudio.API.Graph.SetPortDefault     as SetPortDefault
+import qualified LunaStudio.API.Graph.Transaction        as Transaction
 import           LunaStudio.API.Request                  (Request (..))
 import qualified LunaStudio.API.Request                  as Request
 import           LunaStudio.API.Response                 (Response (..), ResponseOf, InverseOf)
@@ -80,6 +81,7 @@ handlersMap = fromList
     , makeHandler $ autoHandle @SetNodeExpression.Request
     , makeHandler $ autoHandle @SetNodesMeta.Request
     , makeHandler $ autoHandle @SetPortDefault.Request
+    , makeHandler $ autoHandle @Transaction.Request
     ]
 
 type UndoRequests a = (UndoResponseRequest a, RedoResponseRequest a)

--- a/luna-studio/node-editor/src/NodeEditor/Action/NodeDrag.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/NodeDrag.hs
@@ -15,7 +15,7 @@ import           LunaStudio.Data.NodeLoc                    (NodeLoc)
 import           LunaStudio.Data.PortRef                    (InPortRef (InPortRef), OutPortRef (OutPortRef))
 import qualified LunaStudio.Data.PortRef                    as PortRef
 import           LunaStudio.Data.Position                   (Position, move, vector)
-import           NodeEditor.Action.Basic                    (connect, localMoveNodes, moveNodes, selectNodes, updatePortsModeForNode)
+import           NodeEditor.Action.Basic                    (connect, localMoveNodes, moveNodeOnConnection, moveNodes, selectNodes, updatePortsModeForNode, localSetNodesMeta, toMetaUpdate)
 import           NodeEditor.Action.State.Action             (beginActionWithKey, continueActionWithKey, removeActionFromState,
                                                              updateActionWithKey)
 import           NodeEditor.Action.State.Model              (createConnectionModel, getIntersectingConnections)
@@ -146,12 +146,14 @@ handleNodeDragMouseUp evt nodeDrag = do
     else do
         metaUpdate <- Map.fromList . fmap (view nodeLoc &&& view position)
             <$> getSelectedNodes
-        moveNodes metaUpdate
-        withJust (nodeDrag ^. nodeDragSnappedConnId) $ \connId -> do
-            mayConn <- getConnection connId
-            withJust mayConn $ \conn -> do
-                connect (Left $ conn ^. src) $ Right nl
-                connect (Right nl)           $ Left $ conn ^. dst
+        localSetNodesMeta =<< toMetaUpdate metaUpdate
+        print (nodeDrag ^. nodeDragSnappedConnId) 
+        case (nodeDrag ^. nodeDragSnappedConnId) of
+            Just connId -> do
+                mayConn <- getConnection connId
+                withJust mayConn $ \conn ->
+                    moveNodeOnConnection nl conn metaUpdate
+            _           -> moveNodes metaUpdate
     continue stopNodeDrag
 
 

--- a/luna-studio/node-editor/src/NodeEditor/Action/NodeDrag.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Action/NodeDrag.hs
@@ -147,7 +147,6 @@ handleNodeDragMouseUp evt nodeDrag = do
         metaUpdate <- Map.fromList . fmap (view nodeLoc &&& view position)
             <$> getSelectedNodes
         localSetNodesMeta =<< toMetaUpdate metaUpdate
-        print (nodeDrag ^. nodeDragSnappedConnId) 
         case (nodeDrag ^. nodeDragSnappedConnId) of
             Just connId -> do
                 mayConn <- getConnection connId

--- a/luna-studio/node-editor/src/NodeEditor/Event/Batch.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/Batch.hs
@@ -37,6 +37,7 @@ import qualified LunaStudio.API.Graph.SetCode               as SetCode
 import qualified LunaStudio.API.Graph.SetNodeExpression     as SetNodeExpression
 import qualified LunaStudio.API.Graph.SetNodesMeta          as SetNodesMeta
 import qualified LunaStudio.API.Graph.SetPortDefault        as SetPortDefault
+import qualified LunaStudio.API.Graph.Transaction           as Transaction
 import qualified LunaStudio.API.Graph.TypeCheck             as TypeCheck
 import qualified LunaStudio.API.Graph.Undo                  as Undo
 
@@ -78,6 +79,7 @@ data Event = UnknownEvent                                                String
            | SetNodesMetaResponse             (ResponseOf SetNodesMeta.Request)
            | SetPortDefaultResponse         (ResponseOf SetPortDefault.Request)
            | SubstituteResponse                 (ResponseOf Substitute.Request)
+           | TransactionResponse               (ResponseOf Transaction.Request)
            | TypeCheckResponse                   (ResponseOf TypeCheck.Request)
            | UndoResponse                                         Undo.Response
            deriving (Show, Generic, NFData)

--- a/luna-studio/node-editor/src/NodeEditor/Event/Preprocessor/Batch.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/Preprocessor/Batch.hs
@@ -53,6 +53,7 @@ handlers = Map.fromList [ handle AddConnectionResponse
                         , handle SetNodesMetaResponse
                         , handle SetPortDefaultResponse
                         , handle SubstituteResponse
+                        , handle TransactionResponse
                         , handle TypeCheckResponse
                         , handle UndoResponse
                         ]

--- a/luna-studio/node-editor/src/NodeEditor/Handler/Backend/Graph.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Backend/Graph.hs
@@ -37,6 +37,7 @@ import qualified LunaStudio.API.Graph.SetCode               as SetCode
 import qualified LunaStudio.API.Graph.SetNodeExpression     as SetNodeExpression
 import qualified LunaStudio.API.Graph.SetNodesMeta          as SetNodesMeta
 import qualified LunaStudio.API.Graph.SetPortDefault        as SetPortDefault
+import qualified LunaStudio.API.Graph.Transaction           as Transaction
 import qualified LunaStudio.API.Response                    as Response
 import qualified LunaStudio.Data.Connection                 as API
 import qualified LunaStudio.Data.Diff                       as Diff
@@ -515,6 +516,11 @@ handle (Event.Batch ev) = Just $ case ev of
         location      = response ^. Response.request . Substitute.location
         success       = applyDiff location mempty
         failure err _ = logError response err
+
+    TransactionResponse response -> handleResponse response success failure where
+        location = response ^. Response.request . Transaction.location
+        success  = applyDiff location mempty
+        failure err inverse = logError response err
 
     TypeCheckResponse response -> handleResponse response doNothing failure where
         failure err _ = logError response err


### PR DESCRIPTION
### Pull Request Description

Introduces `Transaction` request that encapsulates one or more requests and allows our services to treat them atomically. Currently there are two uses:
* dropping nodes on connections sends a transaction request consisting of two AddConnection requests and one SetNodesMeta
* undoing AddPort with `connectTo` field non-empty, requires removing port and setting previous expressions on all nodes that were connected

GUI code is rather rough, as I think I implemented this functionality in incorrect place(s), so feel free to point that out and I'll move everything where desired.

### Important Notes

- Mention important elements of the design.
- Mention any notable changes to APIs. 

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

