### PR TITLE
Fixes for undoing node actions from code and vice versa

### DIFF
--- a/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
+++ b/libs/batch/plugins/luna-empire/src/Empire/Server/Graph.hs
@@ -152,13 +152,13 @@ handleGetProgram = modifyGraph defInverse action replyResult where
                 || isJust (join $ view Project.visMap . snd <$> mayPrevSettings)
             makeError :: MonadIO m
                 => SomeASTException -> m (GraphLocation, GUIState)
-            makeError e = pure $ (location', GUIState
+            makeError e = liftIO (Graph.prepareGraphError (toException e)) >>= \err -> pure (location', GUIState
                 (Breadcrumb [])
                 mempty
                 def
                 def
                 mempty
-                . Left . Graph.prepareGraphError $ toException e)
+                (Left err))
         (location, guiState) <- handle makeError $ do
             let filePath      = location' ^. GraphLocation.filePath
                 closestBc loc = Api.getClosestBcLocation

--- a/libs/luna-empire/src/Empire/ApiHandlers.hs
+++ b/libs/luna-empire/src/Empire/ApiHandlers.hs
@@ -48,6 +48,7 @@ import qualified LunaStudio.Data.Node             as Node
 import qualified LunaStudio.Data.NodeLoc                 as NodeLoc
 import qualified LunaStudio.Data.PortRef          as PortRef
 import qualified LunaStudio.Data.Project                 as Project
+import qualified LunaStudio.Data.TextDiff                as TextDiff
 import qualified Path
 import qualified System.Log.MLogger                      as Logger
 
@@ -194,7 +195,7 @@ instance Modification CollapseToFunction.Request where
     buildInverse (CollapseToFunction.Request loc@(GraphLocation file _) _) = do
         code <- Graph.withUnit (GraphLocation file def) $ use Graph.code
         cache <- Graph.prepareNodeCache (GraphLocation file def)
-        pure $ SetCode.Request loc code cache
+        pure $ SetCode.Request loc code cache Nothing
 
 instance Modification Copy.Request where
     perform (Copy.Request location nodeLocs) = do
@@ -277,16 +278,16 @@ instance Modification RemovePort.Request where
             (Just oldName)
 
 instance Modification SetCode.Request where
-    perform (SetCode.Request location@(GraphLocation file _) code cache)
+    perform (SetCode.Request location@(GraphLocation file _) code cache cursor)
         = withDiff location $ do
             Graph.withUnit (GraphLocation file def) $ Graph.nodeCache .= cache
             Graph.loadCode location code
-            Graph.resendCode location
+            Graph.resendCodeWithCursor location cursor
             Graph.typecheck location
-    buildInverse (SetCode.Request location@(GraphLocation file _) _ _) = do
+    buildInverse (SetCode.Request location@(GraphLocation file _) _ _ cursor) = do
         cache <- Graph.prepareNodeCache location
         code  <- Graph.withUnit (GraphLocation file def) $ use Graph.code
-        pure $ SetCode.Request location code cache
+        pure $ SetCode.Request location code cache cursor
 
 instance Modification SaveSettings.Request where
     perform (SaveSettings.Request gl settings) = saveSettings gl settings gl
@@ -318,12 +319,14 @@ instance Modification Substitute.Request where
         let file = location ^. GraphLocation.filePath
         withDiff location $ do
             Graph.substituteCodeFromPoints file diffs
-            Graph.resendCode location
+            let cursor = asum $ map (view TextDiff.cursor) diffs
+            Graph.resendCodeWithCursor location cursor
             Graph.typecheck location
-    buildInverse (Substitute.Request location _) = do
+    buildInverse (Substitute.Request location diffs) = do
         code  <- Graph.withUnit (GraphLocation.top location) $ use Graph.code
         cache <- Graph.prepareNodeCache (GraphLocation.top location)
-        pure $ SetCode.Request location code cache
+        let cursor = asum $ map (view TextDiff.cursor) diffs
+        pure $ SetCode.Request location code cache cursor
 
 instance Modification GetBuffer.Request where
     perform (GetBuffer.Request file) = do

--- a/libs/luna-studio-common/src/LunaStudio/API/Graph/SetCode.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Graph/SetCode.hs
@@ -6,6 +6,7 @@ import qualified LunaStudio.API.Graph.Request  as G
 import qualified LunaStudio.API.Topic          as T
 import           LunaStudio.Data.GraphLocation (GraphLocation)
 import           LunaStudio.Data.NodeCache     (NodeCache)
+import           LunaStudio.Data.Point         (Point)
 import           Prologue
 
 
@@ -13,6 +14,7 @@ data Request = Request
     { _location :: GraphLocation
     , _code     :: Text
     , _cache    :: NodeCache
+    , _cursor   :: Maybe Point
     } deriving (Generic, Show)
 
 makeLenses ''Request

--- a/libs/luna-studio-common/src/LunaStudio/API/Response.hs
+++ b/libs/luna-studio-common/src/LunaStudio/API/Response.hs
@@ -186,7 +186,7 @@ type instance ResultOf  SetNodesMeta.Request = Diff
 type instance InverseOf SetPortDefault.Request = SetPortDefault.Request
 type instance ResultOf  SetPortDefault.Request = Diff
 
-type instance InverseOf Substitute.Request = ()
+type instance InverseOf Substitute.Request = SetCode.Request
 type instance ResultOf  Substitute.Request = Diff
 
 type instance InverseOf TypeCheck.Request = ()

--- a/libs/undo-redo/src/Handlers.hs
+++ b/libs/undo-redo/src/Handlers.hs
@@ -20,6 +20,7 @@ import           Data.Map.Strict                         (Map)
 import qualified Data.Map.Strict                         as Map
 import           Data.Maybe
 import           Data.UUID                               as UUID (nil)
+import qualified LunaStudio.API.Atom.Substitute          as Substitute
 import qualified LunaStudio.API.Graph.AddConnection      as AddConnection
 import qualified LunaStudio.API.Graph.AddNode            as AddNode
 import qualified LunaStudio.API.Graph.AddPort            as AddPort
@@ -80,6 +81,7 @@ handlersMap = fromList
     , makeHandler $ autoHandle @SetNodeExpression.Request
     , makeHandler $ autoHandle @SetNodesMeta.Request
     , makeHandler $ autoHandle @SetPortDefault.Request
+    , makeHandler $ autoHandle @Substitute.Request
     ]
 
 type UndoRequests a = (UndoResponseRequest a, RedoResponseRequest a)

--- a/luna-studio/atom/lib/luna-code-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-code-editor-tab.coffee
@@ -106,6 +106,8 @@ module.exports =
                 'core:cut':   (e) => @handleCut   e
                 'core:paste': (e) => @handlePaste e
                 'core:save':  (e) => @handleSave  e
+                'core:undo':  (e) => @handleUndo e
+                'core:redo':  (e) => @handleRedo e
 
         __spans: (markWholeLines) =>
             for s in @getSelections()
@@ -154,6 +156,18 @@ module.exports =
         forceStopChanging: (action) =>
             @afterCodeChanged.push action
             @getBuffer().scheduleDidStopChangingEvent()
+
+        handleUndo: (e) =>
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            @forceStopChanging =>
+                @codeEditor.pushInternalEvent(tag: "Undo")
+
+        handleRedo: (e) =>
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            @forceStopChanging =>
+                @codeEditor.pushInternalEvent(tag: "Redo")
 
         handleCopy: (e) =>
             e.preventDefault()

--- a/luna-studio/lib/src/Common/ClientId.hs
+++ b/luna-studio/lib/src/Common/ClientId.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Common.ClientId (clientId)  where
+
+import           Common.Prelude
+
+import           Data.UUID.Types     (UUID)
+import qualified Data.UUID.Types     as UUID
+
+clientId :: UUID
+clientId = fromJust . UUID.fromString $ "dee28bb6-1e57-4368-9c68-5752980620fd"

--- a/luna-studio/node-editor/package.yaml
+++ b/luna-studio/node-editor/package.yaml
@@ -86,6 +86,7 @@ dependencies:
   - time
   - transformers
   - unordered-containers
+  - uuid
   - uuid-types
   - vector
   - vector-text

--- a/luna-studio/node-editor/src/Main.hs
+++ b/luna-studio/node-editor/src/Main.hs
@@ -2,10 +2,10 @@
 module Main where
 
 import           Common.Prelude
+import           Common.ClientId            (clientId)
 import           Control.Concurrent.Chan    (Chan)
 import qualified Control.Concurrent.Chan    as Chan
 import           Control.Concurrent.MVar
-import Data.UUID (nil)
 import qualified JS.Mount                   as Mount
 import           JS.UUID                    (generateUUID)
 import           NodeEditor.Event.Engine    (LoopRef (LoopRef))
@@ -22,14 +22,13 @@ import           WebSocket                  (WebSocket)
 runApp :: Chan (IO ()) -> WebSocket -> IO ()
 runApp chan socket = do
     random         <- newStdGen
-    -- clientId       <- generateUUID
     let openedFile = Mount.openedFile
     mdo
         let loop = LoopRef chan state
         Engine.scheduleInit loop
         appRef <- Store.createApp (App.mk openedFile) $ Engine.scheduleEvent loop
         React.reactRender Mount.mountPoint (App.app appRef) ()
-        let initState = mkState appRef nil random
+        let initState = mkState appRef clientId random
         state <- newMVar initState
         Engine.connectEventSources socket loop
     App.focus

--- a/luna-studio/node-editor/src/Main.hs
+++ b/luna-studio/node-editor/src/Main.hs
@@ -5,6 +5,7 @@ import           Common.Prelude
 import           Control.Concurrent.Chan    (Chan)
 import qualified Control.Concurrent.Chan    as Chan
 import           Control.Concurrent.MVar
+import Data.UUID (nil)
 import qualified JS.Mount                   as Mount
 import           JS.UUID                    (generateUUID)
 import           NodeEditor.Event.Engine    (LoopRef (LoopRef))
@@ -21,14 +22,14 @@ import           WebSocket                  (WebSocket)
 runApp :: Chan (IO ()) -> WebSocket -> IO ()
 runApp chan socket = do
     random         <- newStdGen
-    clientId       <- generateUUID
+    -- clientId       <- generateUUID
     let openedFile = Mount.openedFile
     mdo
         let loop = LoopRef chan state
         Engine.scheduleInit loop
         appRef <- Store.createApp (App.mk openedFile) $ Engine.scheduleEvent loop
         React.reactRender Mount.mountPoint (App.app appRef) ()
-        let initState = mkState appRef clientId random
+        let initState = mkState appRef nil random
         state <- newMVar initState
         Engine.connectEventSources socket loop
     App.focus

--- a/luna-studio/text-editor/package.yaml
+++ b/luna-studio/text-editor/package.yaml
@@ -52,6 +52,7 @@ dependencies:
   - text-processing
   - time
   - transformers
+  - uuid
   - uuid-types
   - vector-text
 

--- a/luna-studio/text-editor/src/Main.hs
+++ b/luna-studio/text-editor/src/Main.hs
@@ -7,6 +7,7 @@ import qualified Control.Concurrent.Chan as Chan
 import           Control.Concurrent.MVar
 import           System.Random           (newStdGen)
 
+import Data.UUID (nil)
 import           JS.Lexer                (installLexer)
 import           JS.UUID                 (generateUUID)
 import           TextEditor.Event.Engine (LoopRef (LoopRef))
@@ -17,11 +18,11 @@ import           WebSocket               (WebSocket)
 runApp :: Chan (IO ()) -> WebSocket -> IO ()
 runApp chan socket = do
     random       <- newStdGen
-    clientId             <- generateUUID
+    -- clientId             <- generateUUID
     mdo
         let loop = LoopRef chan state
         Engine.scheduleInit loop
-        let initState = mkState clientId random
+        let initState = mkState nil random
         state <- newMVar initState
         Engine.connectEventSources socket loop
 

--- a/luna-studio/text-editor/src/Main.hs
+++ b/luna-studio/text-editor/src/Main.hs
@@ -2,12 +2,12 @@
 module Main where
 
 import           Common.Prelude
+import           Common.ClientId         (clientId)
 import           Control.Concurrent.Chan (Chan)
 import qualified Control.Concurrent.Chan as Chan
 import           Control.Concurrent.MVar
 import           System.Random           (newStdGen)
 
-import Data.UUID (nil)
 import           JS.Lexer                (installLexer)
 import           JS.UUID                 (generateUUID)
 import           TextEditor.Event.Engine (LoopRef (LoopRef))
@@ -18,11 +18,10 @@ import           WebSocket               (WebSocket)
 runApp :: Chan (IO ()) -> WebSocket -> IO ()
 runApp chan socket = do
     random       <- newStdGen
-    -- clientId             <- generateUUID
     mdo
         let loop = LoopRef chan state
         Engine.scheduleInit loop
-        let initState = mkState nil random
+        let initState = mkState clientId random
         state <- newMVar initState
         Engine.connectEventSources socket loop
 

--- a/luna-studio/text-editor/src/TextEditor/Action/Batch.hs
+++ b/luna-studio/text-editor/src/TextEditor/Action/Batch.hs
@@ -61,3 +61,9 @@ interpreterPause = withUUID BatchCmd.interpreterPause
 
 interpreterReload :: Command State ()
 interpreterReload = withUUID BatchCmd.interpreterReload
+
+undo :: Command State ()
+undo = withUUID BatchCmd.undo
+
+redo :: Command State ()
+redo = withUUID BatchCmd.redo

--- a/luna-studio/text-editor/src/TextEditor/Batch/Commands.hs
+++ b/luna-studio/text-editor/src/TextEditor/Batch/Commands.hs
@@ -17,6 +17,8 @@ import qualified LunaStudio.API.Atom.SaveFile       as SaveFile
 import qualified LunaStudio.API.Atom.SetProject     as SetProject
 import qualified LunaStudio.API.Atom.Substitute     as Substitute
 import qualified LunaStudio.API.Control.Interpreter as Interpreter
+import qualified LunaStudio.API.Graph.Redo          as Redo
+import qualified LunaStudio.API.Graph.Undo          as Undo
 import           LunaStudio.Data.GraphLocation      (GraphLocation (..))
 import           LunaStudio.Data.Range              (Range)
 import           LunaStudio.Data.TextDiff           (TextDiff)
@@ -70,6 +72,12 @@ copy path spans uuid guiID = sendRequest $ Message uuid guiID
 paste :: GraphLocation -> [Range] -> [Text] -> UUID -> Maybe UUID -> IO ()
 paste location spans content uuid guiID = sendRequest $ Message uuid guiID
     $ Paste.Request location spans content
+
+undo :: UUID -> Maybe UUID -> IO ()
+undo uuid guiID = sendRequest $ Message uuid guiID $ Undo.Request Undo.UndoRequest
+
+redo :: UUID -> Maybe UUID -> IO ()
+redo uuid guiID = sendRequest $ Message uuid guiID $ Redo.Request Redo.RedoRequest
 
 interpreterPause :: UUID -> Maybe UUID -> IO ()
 interpreterPause uuid guiID = do

--- a/luna-studio/text-editor/src/TextEditor/Event/Batch.hs
+++ b/luna-studio/text-editor/src/TextEditor/Event/Batch.hs
@@ -40,7 +40,7 @@ data BatchEvent
         | ProjectSet                             SetProject.Response
         | SubstituteResponse         (ResponseOf Substitute.Request)
         | SubstituteUpdate                       Substitute.Update
-        deriving (Eq, Show, Generic, NFData)
+        deriving (Show, Generic, NFData)
 
 instance EventName BatchEvent
 instance ToJSON BatchEvent

--- a/luna-studio/text-editor/src/TextEditor/Event/Internal.hs
+++ b/luna-studio/text-editor/src/TextEditor/Event/Internal.hs
@@ -19,8 +19,10 @@ data InternalEvent
     | MoveProject { _oldPath :: FilePath, _newPath :: FilePath }
     | OpenFile    { _path :: FilePath }
     | Paste       { _selections :: [(Int, Int)], _content :: [Text] }
+    | Redo
     | SaveFile    { _path :: FilePath }
     | SetProject  { _path :: FilePath }
+    | Undo
     deriving (Generic, NFData, Show, Typeable)
 
 makeLenses ''InternalEvent

--- a/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
+++ b/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
@@ -27,6 +27,8 @@ handle (Atom (Copy filepath selections)) = Just $ ActBatch.copy filepath $ conve
 handle (Atom (Paste selections content)) = Just $
     withJustM_ JS.activeLocation $ \location ->
         ActBatch.paste location (convert selections) content
+handle (Atom Undo) = Just ActBatch.undo
+handle (Atom Redo) = Just ActBatch.redo
 
 handle (Batch (SubstituteResponse response)) = Just $ handleResponse response doNothing doNothing2
 handle (Batch (BufferGetResponse  response)) = Just $ handleResponse response success doNothing2 where


### PR DESCRIPTION
### Pull Request Description

Replaces default atom behaviour of undoing changes in code by sending whole file as Substitute request and unifies it with out undo/redo infrastructure.

### Important Notes

@pmlodawski @ljkania I have replaced generating client UUID with zeros, because this caused accidental breakage in undo - node editor was considered to be different client than code editor. Ideally, this ID should be generated before and used in these two places. Please comment if you see a way to do that

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

