### PR TITLE
If code changed, report changed expression

### DIFF
--- a/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Diff.hs
@@ -422,7 +422,7 @@ instance Diffable ExpressionNode where
     diff n1 n2 = Diff mods where
         nl   = convert $ n2 ^. Node.nodeId
         mods = catMaybes
-            [ justIf (n1 ^. Node.expression   /= n2 ^. Node.expression)   $ toModification . ModificationSetExpression   nl $ n2 ^. Node.expression
+            [ justIf (n1 ^. Node.code         /= n2 ^. Node.code)         $ toModification . ModificationSetExpression   nl $ n2 ^. Node.expression
             , justIf (n1 ^. Node.isDefinition /= n2 ^. Node.isDefinition) $ toModification . ModificationSetIsDefinition nl $ n2 ^. Node.isDefinition
             , justIf (n1 ^. Node.name         /= n2 ^. Node.name)         $ toModification . ModificationRenameNode      nl $ n2 ^. Node.name
             , justIf (n1 ^. Node.code         /= n2 ^. Node.code)         $ toModification . ModificationSetNodeCode     nl $ n2 ^. Node.code


### PR DESCRIPTION
### Pull Request Description

Because of our usage of pretty printer to provide expressions to GUI, sometimes diff mechanism erroneously thought that they didn't change. When changing expression from e.g. `lam (x: x.at "foo")` to `lam (x: x.at text1)`, GUI did not receive info about changed expression that caused bug #1300.

### Important Notes


### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

