### PR TITLE
Retrying the frontend build

### DIFF
--- a/scripts_build/build.py
+++ b/scripts_build/build.py
@@ -82,7 +82,8 @@ def main ():
     parser.add_argument("--frontend-stack", help="Additional options passed to stack while building frontend", action="append", dest="stack_frontend_args", default=['--install-ghc'])
     parser.add_argument("--runner-stack", help="Additional options passed to stack while building runner", action="append", dest="stack_runner_args", default=['--copy-bins', '--install-ghc'])
     parser.add_argument("--dry-run", help="Do not build, only copy files", action="store_true", dest="dry_run")
-    parser.add_argument("--frontend-retries", action="store", dest="frontend_retries", default="3")
+    parser.add_argument("--frontend-retries", help="Retry the frontend build the given number of times",
+                        action="store", dest="frontend_retries", default="3")
     args = parser.parse_args()
 
     try:

--- a/scripts_build/build.py
+++ b/scripts_build/build.py
@@ -18,11 +18,11 @@ frontend_dir = atom_prepare.prep_path('../luna-studio')
 
 
 def build_app (backend_args, frontend_args, runner_args,
-               gui_url, dev_mode=False, dry_run=False):
+               gui_url, dev_mode=False, dry_run=False, frontend_retries=3):
     try:
         build_runner(runner_args, dry_run)
         build_backend (backend_args, dry_run)
-        build_frontend (frontend_args, gui_url, dev_mode, dry_run)
+        build_frontend (frontend_args, gui_url, dev_mode, dry_run, frontend_retries)
 
     except subprocess.CalledProcessError:
         print("Status : FAIL")
@@ -40,9 +40,10 @@ def build_backend (backend_args, dry_run=False):
         print("Status : FAIL")
         sys.exit(1)
 
-def build_frontend (frontend_args, gui_url, dev_mode=False, dry_run=False):
-    try:
-        print("Building frontend")
+def build_frontend (frontend_args, gui_url, dev_mode=False, dry_run=False, frontend_retries=3):
+    print("Building frontend")
+    
+    def go():
         stack_build.create_bin_dirs()
         if not dry_run:
             stack_build.build_ghcjs(frontend_args, dev_mode)
@@ -50,9 +51,15 @@ def build_frontend (frontend_args, gui_url, dev_mode=False, dry_run=False):
         atom_apm.run(gui_url, frontend_args, dev_mode)
         copy_configs.run()
 
-    except subprocess.CalledProcessError:
-        print("Status : FAIL")
-        sys.exit(1)
+    for r in range(frontend_retries):
+        try:
+            go()
+            return
+        except subprocess.CalledProcessError:
+            print("Retrying the frontend build ({})".format(r))
+
+    print("Status : FAIL")
+    sys.exit(1)
 
 def build_runner(runner_args, dry_run=False):
     try:
@@ -74,8 +81,14 @@ def main ():
     parser.add_argument("--backend-stack", help="Additional options passed to stack while building backend", action="append", dest="stack_backend_args", default=['--copy-bins', '--install-ghc'])
     parser.add_argument("--frontend-stack", help="Additional options passed to stack while building frontend", action="append", dest="stack_frontend_args", default=['--install-ghc'])
     parser.add_argument("--runner-stack", help="Additional options passed to stack while building runner", action="append", dest="stack_runner_args", default=['--copy-bins', '--install-ghc'])
-    parser.add_argument("--dry-run", help="Do not build, only copy files", action="store_true")
+    parser.add_argument("--dry-run", help="Do not build, only copy files", action="store_true", dest="dry_run")
+    parser.add_argument("--frontend-retries", action="store", dest="frontend_retries", default="3")
     args = parser.parse_args()
+
+    try:
+        frontend_retries = int(args.frontend_retries)
+    except ValueError:
+        frontend_retries = 3
 
     if args.backend:
         build_backend(args.stack_backend_args, dry_run=args.dry_run)
@@ -83,11 +96,13 @@ def main ():
         build_runner(args.stack_runner_args, dry_run=args.dry_run)
     elif args.frontend:
         build_frontend(args.stack_frontend_args, args.gui_url,
-                       dev_mode=args.release, dry_run=args.dry_run)
+                       dev_mode=args.release, dry_run=args.dry_run,
+                       frontend_retries=frontend_retries)
     else:
         build_app(args.stack_backend_args, args.stack_frontend_args,
                   args.stack_runner_args, args.gui_url,
-                  dev_mode=args.release, dry_run=args.dry_run)
+                  dev_mode=args.release, dry_run=args.dry_run,
+                  frontend_retries=frontend_retries)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
### Pull Request Description

The frontend build likes to fail randomly. While we wait for the LTS update or removing GHCJS, here's a change that will retry the frontend build a given number of times (3 by default, but you can override it with a command line argument).

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [] The code has been tested where possible.

