### PR TITLE
Added category to the desktop files to fix appimage errors.

### DIFF
--- a/resources/app.desktop
+++ b/resources/app.desktop
@@ -3,3 +3,4 @@ Name=luna-studio
 Exec=bin/public/luna-studio/luna-studio %F
 Icon=luna-studio
 Type=Application
+Categories=Science;DataVisualization;

--- a/resources/app_shared.desktop
+++ b/resources/app_shared.desktop
@@ -3,3 +3,4 @@ Name=Luna Studio
 Exec=luna-studio %F
 Icon=luna-studio
 Type=Application
+Categories=Science;DataVisualization;


### PR DESCRIPTION
### Pull Request Description
This pull request aims to fix packaging failure ( https://github.com/luna/deploy/issues/38 ) related to our .desktop files failing to validate.
It is necessary to add `Category` entry. Its values must belong to the predefined list, see: https://specifications.freedesktop.org/menu-spec/latest/apa.html and https://specifications.freedesktop.org/menu-spec/latest/apas02.html

Note that trailing semicolon is actually required here for validation to pass, even though specification states that it is optional (as this entire field…).

### Important Notes
* together with @wdanilo  we decided to use `Science;DataVisualization;` rather than `Categories=IDE;Development;`
* this PR supersedes https://github.com/luna/luna-studio/pull/1325


### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

