### PR TITLE
Make sure Atom diffs are minimal and do not overwrite contexts

### DIFF
--- a/libs/luna-empire/src/Empire/ApiHandlers.hs
+++ b/libs/luna-empire/src/Empire/ApiHandlers.hs
@@ -425,7 +425,7 @@ instance Modification Substitute.Request where
             Graph.substituteCodeFromPoints file diffs
             let cursor = asum $ map (view TextDiff.cursor) diffs
             Graph.resendCodeWithCursor location cursor
-            Graph.typecheck location
+            Graph.typecheckWithRecompute location
     buildInverse (Substitute.Request location diffs) = do
         code  <- Graph.withUnit (GraphLocation.top location) $ use Graph.code
         cache <- Graph.prepareNodeCache (GraphLocation.top location)

--- a/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
+++ b/libs/luna-empire/src/Empire/Commands/Graph/Code.hs
@@ -36,6 +36,44 @@ import LunaStudio.Data.NodeCache            (nodeIdMap, nodeMetaMap)
 import LunaStudio.Data.Point                (Point)
 import LunaStudio.Data.TextDiff             (TextDiff (TextDiff))
 
+-- | minimizeDiff takes the old code and a diff and strips off the longest
+--   common prefix, shortening the diff.
+--   This step is required due to unexpected nature of Atom diffs,
+--   which sometimes contain the whole file instead of just the relevant
+--   changed part. Applying such a diff as-is results in removal of
+--   markers and losing metadata in the files, breaking the natural flow
+--   of text editor.
+minimizeDiff :: Text -> (Delta, Delta, Text) -> (Delta, Delta, Text)
+minimizeDiff oldCode (beg, end, newCode) = (newBeg, end, minimalCode) where
+    iEnd = fromIntegral end
+    iBeg = fromIntegral beg
+    relevantCode = Text.take (iEnd - iBeg)
+        $ Text.drop iBeg oldCode
+    zipped = zip (Text.unpack relevantCode) (Text.unpack newCode)
+    (eqs, diff) = span (uncurry (==)) zipped
+    equalPrefixLengths = length eqs
+    newBeg = fromIntegral $ iBeg + equalPrefixLengths
+    minimalCode = Text.drop equalPrefixLengths newCode
+
+-- | pointsDiffToDeltas translates a diff from standard Atom shape,
+--   consisting of coordinates in a (row, column) shape to a diff
+--   with coordinates reported as the number of character in a file.
+pointsToDeltas :: Text -> TextDiff -> (Delta, Delta, Text)
+pointsToDeltas code (TextDiff range newCode _) = case range of
+    Just (start, end) ->
+        ( Code.pointToDelta start code
+        , Code.pointToDelta end code
+        , newCode)
+    _ -> (0, fromIntegral $ Text.length code, newCode)
+
+-- | viewDeltasToRealDeltas translate coordinates from markerless text
+--   to text with markers, depending on the diff beginning.
+viewDeltasToRealDeltas :: Text -> Text -> (Delta, Delta) -> (Delta, Delta)
+viewDeltasToRealDeltas markerlessCode = case Text.uncons markerlessCode of
+    Nothing        -> Code.viewDeltasToRealBeforeMarker
+    Just (char, _) -> if isSpace char
+        then Code.viewDeltasToRealBeforeMarker
+        else Code.viewDeltasToReal
 
 substituteCodeFromPoints :: FilePath -> [TextDiff] -> Empire ()
 substituteCodeFromPoints path (breakDiffs -> diffs) = do
@@ -43,30 +81,12 @@ substituteCodeFromPoints path (breakDiffs -> diffs) = do
     changes <- withUnit gl $ do
         oldCode <- use Graph.code
         let noMarkers    = Code.removeMarkers oldCode
-            toDelta (TextDiff range code _) = case range of
-                Just (start, end) ->
-                    ( Code.pointToDelta start noMarkers
-                    , Code.pointToDelta end noMarkers
-                    , code)
-                _ -> (0, fromIntegral $ Text.length noMarkers, code)
-            viewToReal c = case Text.uncons c of
-                Nothing        -> Code.viewDeltasToRealBeforeMarker
-                Just (char, _) -> if isSpace char
-                    then Code.viewDeltasToRealBeforeMarker
-                    else Code.viewDeltasToReal
-            minimizeDiff (beg, end, newCode) = (newBeg, end, minimalCode) where
-                iEnd = fromIntegral end
-                iBeg = fromIntegral beg
-                relevantCode = Text.take (iEnd - iBeg)
-                    $ Text.drop iBeg noMarkers
-                zipped = zip (Text.unpack relevantCode) (Text.unpack newCode)
-                (eqs, diff) = span (uncurry (==)) zipped
-                equalPrefixLengths = length eqs
-                newBeg = fromIntegral $ iBeg + equalPrefixLengths
-                minimalCode = Text.drop equalPrefixLengths newCode
-            toRealDelta (a,b,c) = let (a', b') = (viewToReal c) oldCode (a,b)
-                in (a', b', c)
-        pure $ map (toRealDelta . minimizeDiff . toDelta) diffs
+            toRealDelta (beg, end, c) =
+                let (beg', end') = viewDeltasToRealDeltas c oldCode (beg, end)
+                in (beg', end', c)
+            processDiff = toRealDelta . minimizeDiff noMarkers
+                        . pointsToDeltas noMarkers
+        pure $ processDiff <$> diffs
     substituteCode path changes
 
 -- | removeMarker removes marker at given position, assuming that marker


### PR DESCRIPTION
### Pull Request Description

This fixes #1323. The issue arising was a strange one and in its core is a wrong Atom behavior.
For whatever reason, sometimes when typing, Atom decides to send the whole file as changed instead of just selecting the relevant part. Due to Atom not knowing about markers, it was sending a diff for "whole file" range, containing the whole file, but without markers. This in turn removed the markers from existing code, making the current context (identified by marker) non existent. The new architecture of events made the whole thing a bit more context-sensitive, resulting in a behavior of randomly throwing user to the file toplevel and typechecker failing with a nasty exception. The solution proposed in this PR is to check how long the real diff is and applying the minimal suffix. This makes sure we won't randomly get thrown out of the context unless it really is broken.

### Important Notes

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

