### PR TITLE
Make bootstrap describe its dependencies

### DIFF
--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -1,4 +1,3 @@
-#!/usr/bin/env stack
 {- stack
   script
   --resolver lts-11.22

--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -1,3 +1,12 @@
+#!/usr/bin/env stack
+{- stack
+  script
+  --resolver lts-11.22
+  --package base,exceptions,shelly,text,directory,system-filepath
+-}
+
+-- ^^^ NOTE: resolvers from lts-12 onwards don' work, because shelly 1.8.1 is broken on Windows
+
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric #-}


### PR DESCRIPTION
### Pull Request Description
Thanks to this bootstrap.hs can be "just" executed by stack tool, without any additional knowledge on the caller site.
See also https://github.com/luna/luna-manager/pull/232

### Important Notes
Resolver has been bumped to lts-11. Anything newer won't work because of shelly. Stack script command doesn't allow for extra-deps. Creating a custom shapshot for this feels like an overkill. Should be addressed in the next set of changes to bootstrap/build scripts.

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

