### PR TITLE
Remove installing happy from bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,7 @@ For a tutorial, documentation, explanation of the ideas behind Luna please visit
 ## Hacking on Luna Studio
 Luna's build system is nice and simple, allowing you to bootstrap the compiler
 as long as you have an installation of 
-
-[The Haskell Stack](https://docs.haskellstack.org/en/stable/README/) and the
-Haskell parser generator `happy`. 
-
-You can install the latter just by running `stack install happy`, which should
-build the tool for your system and put it in your `stack` binary folder. 
+[The Haskell Stack](https://docs.haskellstack.org/en/stable/README/). 
 
 ### System Requirements
 While Luna Studio supports Windows as a target operating system, it is not 

--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -161,17 +161,6 @@ installNodeModules = do
 
 -- === Installing Haskell === --
 
-haskellBins :: [T.Text]
-haskellBins = ["happy"]
-
-installHaskellBins :: (MonadSh m, MonadShControl m, MonadIO m) => m ()
-installHaskellBins = do
-    current <- currentPath
-    home    <- liftIO $ System.getHomeDirectory
-    Shelly.appendToPath $ home </> ".local/bin"
-    mapM (Shelly.cmd (current </> stack) "--resolver" "lts-12.16" "install" "--install-ghc") haskellBins
-    sanityCheck "happy" ["--version"]
-
 stackSetupForLunaStudio :: (MonadIO m, MonadSh m, MonadShControl m) => m ()
 stackSetupForLunaStudio = do
     current <- currentPath
@@ -241,4 +230,3 @@ main = do
         downloadLibs
         generateLunaShellScript
         stackSetupForLunaStudio
-        installHaskellBins


### PR DESCRIPTION
### Pull Request Description
There are several problems with the way we install happy:
* stack tries to use inherited stack.yaml context leading to contradictory requiremenets and build failures
* we modify environemnt outside the sandbox (`~/.local/bin`)
* we have no guarantee that `~/.local/bin` is on the PATH and the PATH prepend we do doesn't affect anyone but us (and we exit right after that)

The good news is that happy is not needed after all. 
This PR removes steps code that was installing happy as part of bootstrap routine.

### Important Notes

- Mention important elements of the design.
- Mention any notable changes to APIs. 

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

