### PR TITLE
Passing GHC option `-fno-omit-interface-pragmas` when building backend

### DIFF
--- a/scripts_build/stack_build.py
+++ b/scripts_build/stack_build.py
@@ -39,7 +39,14 @@ def build_backend(backend_args):
     with working_directory(backend_dir):
         # subprocess.check_output(['stack', 'build', 'luna-empire', '--test', '--no-run-tests'])
         sys_opts = ['--ghc-options=-fexternal-interpreter'] if system.windows() else []
-        subprocess.check_output(['stack', 'build'] + sys_opts + backend_args)
+        # Note: -fno-omit-interface-pragmas is specific to our backend stack.yaml project.
+        # It adds -fomit-interface-pragmas option that negatively affects performance.
+        # This script wants to create a fully-optimized build, so we need to overwtite the flag.
+        #
+        # TODO: this behaviour should be eventually optional and script should be usable 
+        # for building development packages (that also care about build-speed).
+        args = sys_opts + backend_args + ['--ghc-options=-fno-omit-interface-pragmas']
+        subprocess.check_output(['stack', 'build'] + args)
 
 def mv_runner(runner):
     if system.windows():


### PR DESCRIPTION
### Pull Request Description
This change follows https://github.com/luna/luna-studio/commit/4bec9e0d742f617ed3fc374f3008a5b24ffefd00 — currently backend builds are not fully optimized by default (they use `-fomit-interface-pragmas`). 
Our build scripts are used to create releasable packages and so they need to pass `-fno-omit-interface-pragmas` to overwrite the default behavior.
In future we will want to have this configurable, but for now we just need the previous behavior of building optimized package. 

### Important Notes
^

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

