### PR TITLE
More explicit & robust windows services-related scripts.

### DIFF
--- a/windows/installAll.bat
+++ b/windows/installAll.bat
@@ -1,11 +1,11 @@
-copy WinSW.NET4.exe s-luna-empire.exe
-copy WinSW.NET4.exe s-luna-undo-redo.exe
-copy WinSW.NET4.exe s-luna-ws-connector.exe
-copy WinSW.NET4.exe s-luna-broker.exe
-s-luna-empire install
-s-luna-undo-redo install
-s-luna-ws-connector install
-s-luna-broker install
+copy /y "%~dp0\WinSW.NET4.exe" "%~dp0\s-luna-empire.exe"
+copy /y "%~dp0\WinSW.NET4.exe" "%~dp0\s-luna-undo-redo.exe"
+copy /y "%~dp0\WinSW.NET4.exe" "%~dp0\s-luna-ws-connector.exe"
+copy /y "%~dp0\WinSW.NET4.exe" "%~dp0\s-luna-broker.exe"
+"%~dp0\s-luna-empire" install
+"%~dp0\s-luna-undo-redo" install
+"%~dp0\s-luna-ws-connector" install
+"%~dp0\s-luna-broker" install
 
 :: below is a super cryptic way to allow local users to start/stop/restart/query status of Luna services
 :: how does it work?
@@ -19,7 +19,7 @@ s-luna-broker install
 :: 4. This needs to be added to _discretionary ACL_ (DACL) of security descriptor (part with D: at the beginning)
 :: 5. Finally, we set the new descriptor on all of our services using "sc.exe sdset _service_ _descriptor_"
 
-%SystemRoot%\System32\sc.exe sdset s-luna-empire "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
-%SystemRoot%\System32\sc.exe sdset s-luna-undo-redo "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
-%SystemRoot%\System32\sc.exe sdset s-luna-ws-connector "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
-%SystemRoot%\System32\sc.exe sdset s-luna-broker "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+"%SystemRoot%\System32\sc.exe" sdset s-luna-empire "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+"%SystemRoot%\System32\sc.exe" sdset s-luna-undo-redo "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+"%SystemRoot%\System32\sc.exe" sdset s-luna-ws-connector "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+"%SystemRoot%\System32\sc.exe" sdset s-luna-broker "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;RPWPDTLO;;;BU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"

--- a/windows/start.bat
+++ b/windows/start.bat
@@ -1,4 +1,4 @@
-s-luna-empire start
-s-luna-undo-redo start
-s-luna-ws-connector start
-s-luna-broker start
+"%~dp0\s-luna-empire" start
+"%~dp0\s-luna-undo-redo" start
+"%~dp0\s-luna-ws-connector" start
+"%~dp0\s-luna-broker" start

--- a/windows/stop.bat
+++ b/windows/stop.bat
@@ -1,4 +1,4 @@
-s-luna-empire stop
-s-luna-undo-redo stop
-s-luna-ws-connector stop
-s-luna-broker stop
+"%~dp0\s-luna-empire" stop
+"%~dp0\s-luna-undo-redo" stop
+"%~dp0\s-luna-ws-connector" stop
+"%~dp0\s-luna-broker" stop

--- a/windows/uninstallAll.bat
+++ b/windows/uninstallAll.bat
@@ -1,8 +1,8 @@
-s-luna-empire stop
-s-luna-undo-redo stop
-s-luna-ws-connector stop
-s-luna-broker stop
-s-luna-empire uninstall
-s-luna-undo-redo uninstall
-s-luna-ws-connector uninstall
-s-luna-broker uninstall
+"%~dp0\s-luna-empire" stop
+"%~dp0\s-luna-undo-redo" stop
+"%~dp0\s-luna-ws-connector" stop
+"%~dp0\s-luna-broker" stop
+"%~dp0\s-luna-empire" uninstall
+"%~dp0\s-luna-undo-redo" uninstall
+"%~dp0\s-luna-ws-connector" uninstall
+"%~dp0\s-luna-broker" uninstall


### PR DESCRIPTION
### Pull Request Description
This PR replaces relative paths to executables and files with full paths using `%~dp0` placeholder that denotes directory with the script. Thanks to that scripts work correctly even when run from different working directory.
Quotes are necessary to properly handle spaces in paths.
The `/y` flag on `copy` is not necessary (it is implied by default when executing scripts), however I added it, so the code behaves the same way as when executed directly in the command prompt.

Note: the arguments to `sc.exe` like `s-luna-empire` are not files but sercive identifiers, and as such are not to be modified here.


### Important Notes


### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

