### PR TITLE
Write UTF-8 when rewriting UTF-8.

### DIFF
--- a/scripts_build/atom_apm.py
+++ b/scripts_build/atom_apm.py
@@ -198,7 +198,7 @@ def apm_packages():
 
 def sed_inplace(filename, pattern, repl):
     pattern_compiled = re.compile(pattern)
-    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as tmp_file:
         with open(filename, 'rb') as src_file:
             data = src_file.read()
             line = None


### PR DESCRIPTION
### Pull Request Description
The `sed_inplace` function rewrites given file. It reads (or at least tries) it as UTF-8, however the encoding for output is not set. So it will fail if default encoding is not compatible with UTF-8 and we encounter not representible unicode codepoint.
This PR sets encoding explicitly to UTF-8 to fix this issue. So far I observed it only on Windows (likely due to using non-utf codepage by default).

### Important Notes

### Checklist

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

