### PR TITLE
Allow copy as fallback when creating symlink fails

### DIFF
--- a/scripts_build/common.py
+++ b/scripts_build/common.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import shutil
 
 
 @contextlib.contextmanager
@@ -14,3 +15,19 @@ def working_directory(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+# FIXME Current package structure requires using symlinks. However, they do not
+#  work currently on Windows. Even if we created them here, 7z archive format
+#  would replace them with copied files anyway.
+#  So as a provisional workaround, we now allow copying files when symlinking
+#  fails - that allows packaging without root privilages on Windows.
+#  To be sorted out as part of https://github.com/luna/luna-manager/issues/236
+def create_symlink_or_copy(link, target):
+    try:
+        link_dir = os.path.dirname(link)
+        link_relative_path = os.path.relpath(link_dir, target)
+        os.symlink(link_relative_path, link)
+    except OSError as e:
+        print("failed to create symlink {} => {}: {}".format(link, target, e))
+        print("falling back to copy")
+        shutil.copy(target, link)

--- a/scripts_build/common.py
+++ b/scripts_build/common.py
@@ -20,7 +20,7 @@ def working_directory(path):
 #  work currently on Windows. Even if we created them here, 7z archive format
 #  would replace them with copied files anyway.
 #  So as a provisional workaround, we now allow copying files when symlinking
-#  fails - that allows packaging without root privilages on Windows.
+#  fails - that allows packaging without root privileges on Windows.
 #  To be sorted out as part of https://github.com/luna/luna-manager/issues/236
 def create_symlink_or_copy(link, target):
     try:

--- a/scripts_build/copy_configs.py
+++ b/scripts_build/copy_configs.py
@@ -2,6 +2,7 @@
 
 import atom_prepare as ap
 import os
+from common import create_symlink_or_copy
 from distutils import dir_util
 from glob import glob
 import shutil
@@ -40,8 +41,7 @@ def link_resources ():
             if os.path.isfile(dst_path):
                 os.remove(dst_path)
             if os.path.isfile(src_path2):
-                os.symlink(os.path.relpath(src_path2,'main/resources/'), dst_path)
-
+                create_symlink_or_copy(dst_path, src_path2)
 
 def copy_atom_configs ():
     dst_path = ap.prep_path('../dist/user-config/atom')

--- a/scripts_build/stack_build.py
+++ b/scripts_build/stack_build.py
@@ -5,7 +5,7 @@ from glob import glob
 import os
 import subprocess
 import system as system
-from common import working_directory
+from common import create_symlink_or_copy, working_directory
 
 app_dir      = ap.prep_path('..')
 backend_dir  = ap.prep_path('../build-config/backend')
@@ -54,7 +54,6 @@ def mv_runner(runner):
         runner_dst = ap.prep_path('../dist/bin/public/luna-studio/luna-studio.exe')
         os.replace(runner_src, runner_dst)
 
-
 def link_main_bin ():
     with working_directory(ap.prep_path('../dist/bin')):
         os.makedirs('main', exist_ok=True)
@@ -63,8 +62,7 @@ def link_main_bin ():
             if os.path.isfile(dst_path):
                 os.remove(dst_path)
             if os.path.isfile(src_path):
-                    os.symlink(os.path.relpath(src_path,'main/'), dst_path)
-
+                create_symlink_or_copy(dst_path, src_path)
 
     # os.symlink('./public/luna-studio', 'main', target_is_directory=True)
 def copy_std_lib ():


### PR DESCRIPTION
### Pull Request Description
See the in-code comment and issue https://github.com/luna/luna-manager/issues/236

This PR allows packaging on Windows without administrator privileges. If creating symlink fails, the file will be just copied. It is not nice workaround, but symlinks are replaced with copies on Windows anyway later in process. Now it is at least described.


### Important Notes
Better solution should be found, see https://github.com/luna/luna-manager/issues/236

### Checklist
- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [ ] The code has been tested where possible.

