### PR TITLE
Paren closer

### DIFF
--- a/luna-studio/atom/keymaps/luna-studio.cson
+++ b/luna-studio/atom/keymaps/luna-studio.cson
@@ -66,32 +66,41 @@
   'ctrl-v'          : 'native!'
 
 '.luna-searcher__input':
-  'ctrl-0'     : 'luna-studio:searcher-accept-0'              # Searcher HintShortcut 0
-  'cmd-0'      : 'luna-studio:searcher-accept-0'              # Searcher HintShortcut 0
-  'ctrl-1'     : 'luna-studio:searcher-accept-1'              # Searcher HintShortcut 1
-  'cmd-1'      : 'luna-studio:searcher-accept-1'              # Searcher HintShortcut 1
-  'ctrl-2'     : 'luna-studio:searcher-accept-2'              # Searcher HintShortcut 2
-  'cmd-2'      : 'luna-studio:searcher-accept-2'              # Searcher HintShortcut 2
-  'ctrl-3'     : 'luna-studio:searcher-accept-3'              # Searcher HintShortcut 3
-  'cmd-3'      : 'luna-studio:searcher-accept-3'              # Searcher HintShortcut 3
-  'ctrl-4'     : 'luna-studio:searcher-accept-4'              # Searcher HintShortcut 4
-  'cmd-4'      : 'luna-studio:searcher-accept-4'              # Searcher HintShortcut 4
-  'ctrl-5'     : 'luna-studio:searcher-accept-5'              # Searcher HintShortcut 5
-  'cmd-5'      : 'luna-studio:searcher-accept-5'              # Searcher HintShortcut 5
-  'ctrl-6'     : 'luna-studio:searcher-accept-6'              # Searcher HintShortcut 6
-  'cmd-6'      : 'luna-studio:searcher-accept-6'              # Searcher HintShortcut 6
-  'ctrl-7'     : 'luna-studio:searcher-accept-7'              # Searcher HintShortcut 7
-  'cmd-7'      : 'luna-studio:searcher-accept-7'              # Searcher HintShortcut 7
-  'ctrl-8'     : 'luna-studio:searcher-accept-8'              # Searcher HintShortcut 8
-  'cmd-8'      : 'luna-studio:searcher-accept-8'              # Searcher HintShortcut 8
-  'ctrl-9'     : 'luna-studio:searcher-accept-9'              # Searcher HintShortcut 9
-  'cmd-9'      : 'luna-studio:searcher-accept-9'              # Searcher HintShortcut 9
-  'ctrl-enter' : 'luna-studio:searcher-accept-input'          # Searcher AcceptInput
-  'cmd-enter'  : 'luna-studio:searcher-accept-input'          # Searcher AcceptInput
-  'down'       : 'luna-studio:searcher-move-down'             # Searcher MoveDown
-  'enter'      : 'luna-studio:searcher-accept'                # Searcher Accept
-  'tab'        : 'luna-studio:searcher-tab-pressed'           # Searcher TabPressed
-  'up'         : 'luna-studio:searcher-move-up'               # Searcher MoveUp
+  'ctrl-0'       : 'luna-studio:searcher-accept-0'
+  'cmd-0'        : 'luna-studio:searcher-accept-0'
+  'ctrl-1'       : 'luna-studio:searcher-accept-1'
+  'cmd-1'        : 'luna-studio:searcher-accept-1'
+  'ctrl-2'       : 'luna-studio:searcher-accept-2'
+  'cmd-2'        : 'luna-studio:searcher-accept-2'
+  'ctrl-3'       : 'luna-studio:searcher-accept-3'
+  'cmd-3'        : 'luna-studio:searcher-accept-3'
+  'ctrl-4'       : 'luna-studio:searcher-accept-4'
+  'cmd-4'        : 'luna-studio:searcher-accept-4'
+  'ctrl-5'       : 'luna-studio:searcher-accept-5'
+  'cmd-5'        : 'luna-studio:searcher-accept-5'
+  'ctrl-6'       : 'luna-studio:searcher-accept-6'
+  'cmd-6'        : 'luna-studio:searcher-accept-6'
+  'ctrl-7'       : 'luna-studio:searcher-accept-7'
+  'cmd-7'        : 'luna-studio:searcher-accept-7'
+  'ctrl-8'       : 'luna-studio:searcher-accept-8'
+  'cmd-8'        : 'luna-studio:searcher-accept-8'
+  'ctrl-9'       : 'luna-studio:searcher-accept-9'
+  'cmd-9'        : 'luna-studio:searcher-accept-9'
+  'ctrl-enter'   : 'luna-studio:searcher-accept-input'
+  'cmd-enter'    : 'luna-studio:searcher-accept-input'
+  'down'         : 'luna-studio:searcher-move-down'
+  'enter'        : 'luna-studio:searcher-accept'
+  'tab'          : 'luna-studio:searcher-tab-pressed'
+  'up'           : 'luna-studio:searcher-move-up'
+  'ctrl-z'       : 'luna-studio:searcher-undo'
+  'cmd-z'        : 'luna-studio:searcher-undo'
+  'ctrl-shift-z' : 'luna-studio:searcher-redo'
+  'cmd-shift-z'  : 'luna-studio:searcher-redo'
+  'ctrl-y'       : 'luna-studio:searcher-redo'
+  'cmd-y'        : 'luna-studio:searcher-redo'
+  '('            : 'luna-studio:searcher-paren-open'
+  ')'            : 'luna-studio:searcher-paren-close'
+  'backspace'    : 'luna-studio:searcher-backspace'
 
 '.luna-studio':
   # camera

--- a/luna-studio/atom/lib/luna-node-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-node-editor-tab.coffee
@@ -104,6 +104,11 @@ class LunaNodeEditorTab extends View
             'luna-studio:searcher-move-down':    => @pushSearcherEvent "MoveDown"
             'luna-studio:searcher-move-left':    => @pushSearcherEvent "MoveLeft"
             'luna-studio:searcher-move-up':      => @pushSearcherEvent "MoveUp"
+            'luna-studio:searcher-paren-open':   => @pushSearcherEvent "ParenOpen"
+            'luna-studio:searcher-paren-close':  => @pushSearcherEvent "ParenClose"
+            'luna-studio:searcher-backspace':    => @pushSearcherEvent "Backspace"
+            'luna-studio:searcher-undo':         => @pushSearcherEvent "Undo"
+            'luna-studio:searcher-redo':         => @pushSearcherEvent "Redo"
 
 
     handleClose: (e) =>

--- a/luna-studio/node-editor-view/src/JS/Searcher.hs
+++ b/luna-studio/node-editor-view/src/JS/Searcher.hs
@@ -21,3 +21,7 @@ focus = UI.focus searcherId
 
 setSelection :: MonadIO m => Int -> Int -> m ()
 setSelection = liftIO .: setSelection' searcherId
+
+getSelection :: MonadIO m => m (Int, Int)
+getSelection = liftIO $ (,) <$> selectionStart searcherId
+                            <*> selectionEnd   searcherId

--- a/luna-studio/node-editor-view/src/NodeEditor/Event/KeyMap.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/Event/KeyMap.hs
@@ -5,7 +5,6 @@ import           React.Flux                      (KeyboardEvent)
 import           Common.Prelude
 import qualified NodeEditor.Event.Keys           as Keys
 import           NodeEditor.Event.Shortcut       (Command (..))
-import qualified NodeEditor.React.Event.Searcher as Searcher
 import qualified React.Flux                      as React
 
 
@@ -65,14 +64,3 @@ handleKeyApp evt
     | Keys.withCtrlShift    evt Keys.m          = Just MockClearMonads
     --
     | otherwise                                 = Nothing
-
-handleKeySearcher :: KeyboardEvent -> Maybe Searcher.Event
-handleKeySearcher evt
-    | Keys.withoutMods   evt Keys.backspace = Just   Searcher.MoveLeft
-    | Keys.withoutMods   evt Keys.downArrow = Just   Searcher.MoveDown
-    | Keys.withoutMods   evt Keys.enter     = Just   Searcher.Accept
-    | Keys.withCtrl      evt Keys.enter     = Just   Searcher.AcceptInput
-    | Keys.digitWithCtrl evt                = Just $ Searcher.HintShortcut $ (React.keyCode evt) - Keys.zero
-    | Keys.withoutMods   evt Keys.tab       = Just   Searcher.TabPressed
-    | Keys.withoutMods   evt Keys.upArrow   = Just   Searcher.MoveUp
-    | otherwise                             = Nothing

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Event/Searcher.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Event/Searcher.hs
@@ -21,6 +21,12 @@ data Event = InputChanged Text Int Int
            | MoveLeft
            | KeyDown KeyboardEvent
            | KeyUp   KeyboardEvent
-            deriving (FromJSON, Generic, NFData, Show, Typeable)
+           | ParenOpen
+           | ParenClose
+           | Backspace
+           | Undo
+           | Redo
+           | SelectionChanged
+           deriving (FromJSON, Generic, NFData, Show, Typeable)
 
 instance EventName Event

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Event/Searcher.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Event/Searcher.hs
@@ -10,23 +10,24 @@ import           Data.Aeson        (FromJSON)
 import           React.Flux        (KeyboardEvent)
 
 
-data Event = InputChanged Text Int Int
-           | Accept
-           | AcceptInput
-           | HintShortcut   Int
-           | AcceptWithHint Int
-           | TabPressed
-           | MoveDown
-           | MoveUp
-           | MoveLeft
-           | KeyDown KeyboardEvent
-           | KeyUp   KeyboardEvent
-           | ParenOpen
-           | ParenClose
-           | Backspace
-           | Undo
-           | Redo
-           | SelectionChanged
-           deriving (FromJSON, Generic, NFData, Show, Typeable)
+data Event
+    = InputChanged Text Int Int
+    | Accept
+    | AcceptInput
+    | HintShortcut   Int
+    | AcceptWithHint Int
+    | TabPressed
+    | MoveDown
+    | MoveUp
+    | MoveLeft
+    | KeyDown KeyboardEvent
+    | KeyUp   KeyboardEvent
+    | ParenOpen
+    | ParenClose
+    | Backspace
+    | Undo
+    | Redo
+    | SelectionChanged
+    deriving (FromJSON, Generic, NFData, Show, Typeable)
 
 instance EventName Event

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher.hs
@@ -7,12 +7,13 @@ import qualified LunaStudio.Data.NodeLoc                   as NodeLoc
 import qualified NodeEditor.React.Model.Searcher.Mode      as Mode
 import qualified NodeEditor.React.Model.Searcher.Mode.Node as Node
 
-import LunaStudio.Data.NodeLoc               (NodeLoc)
-import NodeEditor.React.Model.Searcher.Hint  (Hint)
-import NodeEditor.React.Model.Searcher.Input (Input)
-import NodeEditor.React.Model.Searcher.Mode  (Mode)
-import NodeEditor.React.Model.Visualization  (RunningVisualization)
-import Searcher.Data.Result                  (Result)
+import LunaStudio.Data.NodeLoc                  (NodeLoc)
+import NodeEditor.React.Model.Searcher.Hint     (Hint)
+import NodeEditor.React.Model.Searcher.Input    (Input)
+import NodeEditor.React.Model.Searcher.Mode     (Mode)
+import NodeEditor.React.Model.Searcher.UndoRedo (UndoRedoState)
+import NodeEditor.React.Model.Visualization     (RunningVisualization)
+import Searcher.Data.Result                     (Result)
 
 
 ----------------------
@@ -28,6 +29,7 @@ data Searcher = Searcher
     , _selectedPosition :: Maybe Int
     , _mode             :: Mode
     , _waiting          :: Bool
+    , _undoRedo         :: UndoRedoState
     } deriving (Eq, Generic, Show)
 
 makeLenses ''Searcher
@@ -37,8 +39,8 @@ instance NFData Searcher
 
 selectedResult :: Getter Searcher (Maybe (Result Hint))
 selectedResult = to $ \s -> let
-    mayPosition = s ^. selectedPosition
-    atPosition  = \p -> s ^? results . ix p
+    mayPosition  = s ^. selectedPosition
+    atPosition p = s ^? results . ix p
     in join $! atPosition <$> mayPosition
 {-# INLINE selectedResult #-}
 
@@ -74,7 +76,7 @@ visibleHintsNumber = 10
 mkProperties :: Searcher -> FilePath -> Properties
 mkProperties = \s vlp -> let
     selected        = fromMaybe def $! s ^. selectedPosition
-    limitResults    = \r -> take visibleHintsNumber $! drop selected r
+    limitResults r  = take visibleHintsNumber $! drop selected r
     visibleSearcher = s & results %~ limitResults
                         & selectedPosition %~ fmap (subtract selected)
     in Properties visibleSearcher vlp

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module NodeEditor.React.Model.Searcher.UndoRedo where
 
 import Common.Prelude
@@ -9,15 +11,15 @@ import Common.Prelude
 -- === Definition === --
 
 data InputState = InputState
-    { _text :: Text
+    { _text           :: Text
     , _selectionStart :: Int
-    , _selectionEnd :: Int
+    , _selectionEnd   :: Int
     } deriving (Show, Eq, Generic)
 
 makeLenses ''InputState
 
 instance NFData  InputState
-instance Default InputState where def = InputState "" 0 0
+instance Default InputState where def = InputState mempty 0 0
 
 ---------------------------
 -- === UndoRedoState === --
@@ -43,19 +45,19 @@ mk = UndoRedoState def def
 
 undo :: UndoRedoState -> UndoRedoState
 undo st = case st ^. undoStack of
-    []         -> st
-    inp : inps -> st & undoStack .~ inps
-                     & redoStack %~ (inp :)
+    []             -> st
+    input : inputs -> st & undoStack .~ inputs
+                         & redoStack %~ (input :)
 
 redo :: UndoRedoState -> UndoRedoState
 redo st = case st ^. redoStack of
     []         -> st
-    inp : inps -> st & undoStack %~ (inp :)
-                     & redoStack .~ inps
+    input : inputs -> st & undoStack %~ (input :)
+                         & redoStack .~ inputs
 
 setInput :: InputState -> UndoRedoState -> UndoRedoState
-setInput inp urSt = urSt & undoStack %~ (inp :)
-                         & redoStack .~ []
+setInput input urSt = urSt & undoStack %~ (input :)
+                           & redoStack .~ []
 
 setSelection :: Int -> Int -> UndoRedoState -> UndoRedoState
 setSelection start end = (set (currentInput . selectionStart) start)
@@ -66,9 +68,9 @@ setSelection start end = (set (currentInput . selectionStart) start)
 currentInput :: Lens' UndoRedoState InputState
 currentInput = lens getter setter where
     getter ur = case ur ^. undoStack of
-        []        -> ur ^. initial
-        (inp : _) -> inp
-    setter ur inp = case ur ^. undoStack of
-        []      -> ur & initial .~ inp
-        (_ : _) -> ur & undoStack . ix 0 .~ inp
+        []          -> ur ^. initial
+        (input : _) -> input
+    setter ur input = case ur ^. undoStack of
+        []      -> ur & initial .~ input
+        (_ : _) -> ur & undoStack . ix 0 .~ input
 

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
@@ -2,6 +2,12 @@ module NodeEditor.React.Model.Searcher.UndoRedo where
 
 import Common.Prelude
 
+------------------------
+-- === InputState === --
+------------------------
+
+-- === Definition === --
+
 data InputState = InputState
     { _text :: Text
     , _selectionStart :: Int
@@ -12,6 +18,12 @@ makeLenses ''InputState
 
 instance NFData  InputState
 instance Default InputState where def = InputState "" 0 0
+
+---------------------------
+-- === UndoRedoState === --
+---------------------------
+
+-- === Definition === --
 
 data UndoRedoState = UndoRedoState
     { _undoStack :: [InputState]
@@ -24,17 +36,10 @@ makeLenses ''UndoRedoState
 instance NFData  UndoRedoState
 instance Default UndoRedoState where def = UndoRedoState def def def
 
+-- === Public API === --
+
 mk :: InputState -> UndoRedoState
 mk = UndoRedoState def def
-
-currentInput :: Lens' UndoRedoState InputState
-currentInput = lens getter setter where
-    getter ur = case ur ^. undoStack of
-        []        -> ur ^. initial
-        (inp : _) -> inp
-    setter ur inp = case ur ^. undoStack of
-        []      -> ur & initial .~ inp
-        (_ : _) -> ur & undoStack . ix 0 .~ inp
 
 undo :: UndoRedoState -> UndoRedoState
 undo st = case st ^. undoStack of
@@ -55,3 +60,15 @@ setInput inp urSt = urSt & undoStack %~ (inp :)
 setSelection :: Int -> Int -> UndoRedoState -> UndoRedoState
 setSelection start end = (set (currentInput . selectionStart) start)
                        . (set (currentInput . selectionEnd)   end)
+
+-- === Internal API === --
+
+currentInput :: Lens' UndoRedoState InputState
+currentInput = lens getter setter where
+    getter ur = case ur ^. undoStack of
+        []        -> ur ^. initial
+        (inp : _) -> inp
+    setter ur inp = case ur ^. undoStack of
+        []      -> ur & initial .~ inp
+        (_ : _) -> ur & undoStack . ix 0 .~ inp
+

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
@@ -51,7 +51,7 @@ undo st = case st ^. undoStack of
 
 redo :: UndoRedoState -> UndoRedoState
 redo st = case st ^. redoStack of
-    []         -> st
+    []             -> st
     input : inputs -> st & undoStack %~ (input :)
                          & redoStack .~ inputs
 
@@ -60,8 +60,8 @@ setInput input urSt = urSt & undoStack %~ (input :)
                            & redoStack .~ []
 
 setSelection :: Int -> Int -> UndoRedoState -> UndoRedoState
-setSelection start end = (set (currentInput . selectionStart) start)
-                       . (set (currentInput . selectionEnd)   end)
+setSelection start end = set (currentInput . selectionStart) start
+                       . set (currentInput . selectionEnd)   end
 
 -- === Internal API === --
 

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/UndoRedo.hs
@@ -1,0 +1,57 @@
+module NodeEditor.React.Model.Searcher.UndoRedo where
+
+import Common.Prelude
+
+data InputState = InputState
+    { _text :: Text
+    , _selectionStart :: Int
+    , _selectionEnd :: Int
+    } deriving (Show, Eq, Generic)
+
+makeLenses ''InputState
+
+instance NFData  InputState
+instance Default InputState where def = InputState "" 0 0
+
+data UndoRedoState = UndoRedoState
+    { _undoStack :: [InputState]
+    , _redoStack :: [InputState]
+    , _initial   :: InputState
+    } deriving (Show, Eq, Generic)
+
+makeLenses ''UndoRedoState
+
+instance NFData  UndoRedoState
+instance Default UndoRedoState where def = UndoRedoState def def def
+
+mk :: InputState -> UndoRedoState
+mk = UndoRedoState def def
+
+currentInput :: Lens' UndoRedoState InputState
+currentInput = lens getter setter where
+    getter ur = case ur ^. undoStack of
+        []        -> ur ^. initial
+        (inp : _) -> inp
+    setter ur inp = case ur ^. undoStack of
+        []      -> ur & initial .~ inp
+        (_ : _) -> ur & undoStack . ix 0 .~ inp
+
+undo :: UndoRedoState -> UndoRedoState
+undo st = case st ^. undoStack of
+    []         -> st
+    inp : inps -> st & undoStack .~ inps
+                     & redoStack %~ (inp :)
+
+redo :: UndoRedoState -> UndoRedoState
+redo st = case st ^. redoStack of
+    []         -> st
+    inp : inps -> st & undoStack %~ (inp :)
+                     & redoStack .~ inps
+
+setInput :: InputState -> UndoRedoState -> UndoRedoState
+setInput inp urSt = urSt & undoStack %~ (inp :)
+                         & redoStack .~ []
+
+setSelection :: Int -> Int -> UndoRedoState -> UndoRedoState
+setSelection start end = (set (currentInput . selectionStart) start)
+                       . (set (currentInput . selectionEnd)   end)

--- a/luna-studio/node-editor-view/src/NodeEditor/React/View/Searcher.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/View/Searcher.hs
@@ -27,16 +27,6 @@ import Searcher.Data.Result                (Result, match)
 name :: JSString
 name = "searcher"
 
-handleKeyDown :: IsRef ref => ref -> React.Event -> KeyboardEvent -> [SomeStoreAction]
-handleKeyDown ref e k = prevent $ stopPropagation e : dispatch' where
-    prevent   = if Keys.withoutMods k Keys.tab
-                || Keys.withoutMods k Keys.upArrow
-                || Keys.withoutMods k Keys.downArrow
-                || Keys.digitWithCtrl k then (preventDefault e :) else id
-    dispatch' = dispatch ref $ if Keys.withoutMods k Keys.esc then
-            UI.AppEvent $ App.KeyDown k
-        else UI.SearcherEvent $ KeyDown k
-
 searcher :: IsRef ref => ReactView (ref, Searcher.Properties)
 searcher =  React.defineView name $ \(ref, properties) -> do
     let s           = properties ^. Searcher.searcher
@@ -79,12 +69,12 @@ searcher =  React.defineView name $ \(ref, properties) -> do
             [ "key"         $= "searchInput"
             , "className"   $= inputClasses
             , "id"          $= searcherId
-            , onKeyDown     $ handleKeyDown ref
             , onKeyUp       $ \_ k -> dispatch ref $ UI.SearcherEvent $ KeyUp k
             , onChange      $ \e -> let val = target e "value"
                                         ss  = target e "selectionStart"
                                         se  = target e "selectionEnd"
                                     in dispatch ref $ UI.SearcherEvent $ InputChanged val ss se
+            , onClick       $ \_ _ -> dispatch ref $ UI.SearcherEvent SelectionChanged
             ] <> mayCustomInput )
 
     -- div_

--- a/luna-studio/node-editor/src/NodeEditor/Event/Preprocessor/Shortcut.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Event/Preprocessor/Shortcut.hs
@@ -2,7 +2,7 @@ module NodeEditor.Event.Preprocessor.Shortcut where
 
 import           Common.Prelude
 import           NodeEditor.Event.Event          (Event (Shortcut, UI))
-import           NodeEditor.Event.KeyMap         (handleKeyApp, handleKeySearcher)
+import           NodeEditor.Event.KeyMap         (handleKeyApp)
 import qualified NodeEditor.Event.Shortcut       as Shortcut
 import           NodeEditor.Event.UI             (UIEvent (AppEvent, SearcherEvent))
 import qualified NodeEditor.React.Event.App      as App
@@ -11,5 +11,4 @@ import qualified NodeEditor.React.Event.Searcher as Searcher
 
 process :: Event -> Maybe Event
 process (UI (AppEvent      (App.KeyDown      e))) = Shortcut . flip Shortcut.Event def <$> handleKeyApp e
-process (UI (SearcherEvent (Searcher.KeyDown e))) = UI . SearcherEvent <$> handleKeySearcher e
 process _ = Nothing

--- a/luna-studio/node-editor/src/NodeEditor/Handler/Searcher.hs
+++ b/luna-studio/node-editor/src/NodeEditor/Handler/Searcher.hs
@@ -36,7 +36,7 @@ handle _ _ = Nothing
 
 handleEvent :: (Event -> IO ()) -> Searcher.Event -> Command State ()
 handleEvent scheduleEvent = \case
-    Searcher.InputChanged input ss se -> continue $ Searcher.updateInput input ss se
+    Searcher.InputChanged input ss se -> continue $ Searcher.modifyInput input ss se
     Searcher.Accept                   -> continue $ Searcher.accept scheduleEvent
     Searcher.AcceptInput              -> continue $ Searcher.withHint 0 (Searcher.accept scheduleEvent)
     Searcher.AcceptWithHint i         -> continue $ Searcher.withHint i (Searcher.accept scheduleEvent)
@@ -46,4 +46,10 @@ handleEvent scheduleEvent = \case
     -- Searcher.KeyUp k                  -> when (Keys.withoutMods k Keys.backspace) $ continue Searcher.enableRollback
     -- Searcher.MoveLeft                 -> continue Searcher.tryRollback
     Searcher.MoveUp                   -> continue Searcher.selectNextHint
+    Searcher.ParenOpen                -> continue $ Searcher.openParen
+    Searcher.ParenClose               -> continue $ Searcher.closeParen
+    Searcher.Backspace                -> continue $ Searcher.backspace
+    Searcher.Undo                     -> continue $ Searcher.undo
+    Searcher.Redo                     -> continue $ Searcher.redo
+    Searcher.SelectionChanged         -> continue $ Searcher.updateSelection
     _                                 -> pure ()


### PR DESCRIPTION
### Pull Request Description

This PR brings automatic parentheses closing capability to searcher.

### Important Notes

1. Design is based on the behavior of analogous feature in Atom and VS Code. In particular:
    - Typing `(` before line end, whitespace or some particular characters (`:`, `)`, `]`) results in inserting `)` after the cursor.
    - In a situation like `(<cursor>)`, pressing backspace removes both opening and closing paren.
    - Typing `)` before a closing paren results in cursor jumping after the paren, without typing anything.

2. There was some obsolete event handling code that looked very promising but did nothing, other than wasting a couple hours of my time. It's deleted in this PR. Nothing changed in the behavior after this.

3. JS is not very good in handling undo-redo in inputs in the presence of programatic input changes. It just doesn't take them into account. This forced me to introduce a custom undo-redo system. It sometimes behaves counter-intuitively wrt. cursor position after undo. It is not easily avoidable in the current architecture (GUI uses an old react version, without the events necessary to handle all modes of cursors movement). This, however, should not annoy the user in most scenarios. If it does, there are additional steps we can take (i.e. reimplementing _all_ cursor movement modes, like arrow keys or Home/End, in custom code), but after consultation with @wdanilo we've decided not to do it now.


### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

