### PR TITLE
Properly handle undo-redo responses in text

### DIFF
--- a/libs/luna-empire/src/Empire/ApiHandlers.hs
+++ b/libs/luna-empire/src/Empire/ApiHandlers.hs
@@ -424,7 +424,6 @@ instance Modification Substitute.Request where
         withDiff location $ do
             Graph.substituteCodeFromPoints file diffs
             let cursor = asum $ map (view TextDiff.cursor) diffs
-            Graph.resendCodeWithCursor location cursor
             Graph.typecheckWithRecompute location
     buildInverse (Substitute.Request location diffs) = do
         code  <- Graph.withUnit (GraphLocation.top location) $ use Graph.code

--- a/luna-studio/atom/lib/luna-code-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-code-editor-tab.coffee
@@ -213,11 +213,14 @@ module.exports =
                 for {_newText: text, _range: range, _cursor: cursor} in diffs
                     @omitDiff(text)
                     if range?
-                        @setTextInBufferRange(range, text)
+                        fixedRange = [[range[0]._row, range[0]._column],
+                                      [range[1]._row, range[1]._column]]
+                        @setTextInBufferRange(fixedRange, text)
                     else
                         @setText(text)
                     if cursor?
-                        selections.push([[cursor._row, cursor._column], [cursor._row, cursor._column]])
+                        selections.push([[cursor._row, cursor._column],
+                                         [cursor._row, cursor._column]])
                 if selections.length > 0
                     @setSelectedBufferRanges(selections)
 

--- a/luna-studio/atom/lib/luna-code-editor-tab.coffee
+++ b/luna-studio/atom/lib/luna-code-editor-tab.coffee
@@ -1,4 +1,4 @@
-{TextEditor, TextBuffer} = require 'atom'
+{TextEditor, TextBuffer, Range} = require 'atom'
 {TextEditorView, View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'event-kit'
 path = require 'path'
@@ -57,6 +57,60 @@ TextBuffer::subscribeToFileOverride = (codeEditor) ->
 
     @fileSubscriptions.add @file.onWillThrowWatchError (errorObject) =>
         @emitter.emit 'will-throw-watch-error', errorObject
+
+################################################################################
+################################## Hack Zone ###################################
+################################################################################
+## This section is a hack designed to get around Atom's event throttling.
+## It is needed for programatically triggered changes, so that we know that
+## those are indeed programatically triggered and can ignored them.
+## It is mostly a blatant copy-paste from Atom repo, since the current (1.18.0)
+## version does not expose this functionality.
+## This code is unnecessary on newer versions of Atom and other editors.
+## If the out-of-the-box buffer defines the `#emitDidStopChangingEvent` method,
+## remove this code. Keep this in mind when maintaining this code.
+
+
+normalizePatchChanges = (changes) ->
+    changes.map (change) =>
+        oldRange = new Range(change.oldStart, change.oldEnd)
+        newRange = new Range(change.newStart, change.newEnd)
+        oldText = change.oldText
+        newText = change.newText
+        new TextChange(oldRange, newRange, oldText, newText)
+
+class TextChange
+    constructor: (@oldRange, @newRange, @oldText, @newText) ->
+
+Object.defineProperty TextChange.prototype, 'start',
+    get: () ->
+        @newRange.start
+    enumerable: false
+
+Object.defineProperty TextChange.prototype, 'oldExtent',
+    get: () ->
+        @oldRange.getExtent
+    enumerable: false
+
+Object.defineProperty TextChange.prototype, 'newExtent',
+    get: () ->
+        @newRange.getExtent
+    enumerable: false
+
+TextBuffer::emitDidStopChangingEvent = ->
+    patches = @patchesSinceLastStoppedChangingEvent
+    window.patches = patches
+    @patchesSinceLastStoppedChangingEvent = []
+    modifiedStatus = @isModified()
+    for patch in patches
+        @emitter.emit 'did-stop-changing',
+            changes: Object.freeze(normalizePatchChanges(patch.getHunks()))
+    @emitModifiedStatusChanged(modifiedStatus)
+
+################################################################################
+############################### End of Hack Zone ###############################
+################################################################################
+
 
 module.exports =
     class LunaCodeEditorTab extends TextEditor
@@ -221,6 +275,7 @@ module.exports =
                     if cursor?
                         selections.push([[cursor._row, cursor._column],
                                          [cursor._row, cursor._column]])
+                    @getBuffer().emitDidStopChangingEvent()
                 if selections.length > 0
                     @setSelectedBufferRanges(selections)
 

--- a/luna-studio/text-editor/src/TextEditor/Action/Batch.hs
+++ b/luna-studio/text-editor/src/TextEditor/Action/Batch.hs
@@ -1,14 +1,17 @@
 module TextEditor.Action.Batch  where
 
-import           Common.Action.Command         (Command)
-import           Common.Prelude
-import           Data.UUID.Types               (UUID)
-import           LunaStudio.Data.GraphLocation (GraphLocation)
-import           LunaStudio.Data.Range         (Range)
-import           LunaStudio.Data.TextDiff      (TextDiff)
-import           TextEditor.Action.UUID        (registerRequest)
-import qualified TextEditor.Batch.Commands     as BatchCmd
-import           TextEditor.State.Global       (State, clientId)
+import Common.Prelude
+
+import qualified TextEditor.Batch.Commands as BatchCmd
+import qualified TextEditor.State.Global   as State
+
+import Common.Action.Command         (Command)
+import Data.UUID.Types               (UUID)
+import LunaStudio.Data.GraphLocation (GraphLocation)
+import LunaStudio.Data.Range         (Range)
+import LunaStudio.Data.TextDiff      (TextDiff)
+import TextEditor.Action.UUID        (registerRequest)
+import TextEditor.State.Global       (State, clientId)
 
 
 withUUID :: (UUID -> Maybe UUID -> IO ()) -> Command State ()
@@ -45,7 +48,11 @@ setProject :: FilePath -> Command State ()
 setProject = withUUID . BatchCmd.setProject
 
 substitute :: GraphLocation -> [TextDiff] -> Command State ()
-substitute = withUUID .: BatchCmd.substitute
+substitute location diffs = do
+    uuid  <- registerRequest
+    guiId <- use clientId
+    State.ignoreResponse uuid
+    liftIO $ BatchCmd.substitute location diffs uuid (Just guiId)
 
 copy :: FilePath -> [Range] -> Command State ()
 copy = withUUID .: BatchCmd.copy

--- a/luna-studio/text-editor/src/TextEditor/Batch/Commands.hs
+++ b/luna-studio/text-editor/src/TextEditor/Batch/Commands.hs
@@ -1,9 +1,7 @@
 module TextEditor.Batch.Commands where
 
-import           Common.Batch.Connector.Connection  (Message (Message), sendRequest)
-import           Common.Prelude                     hiding (span)
-import           Data.UUID.Types                    (UUID)
-import           JS.Atom                            (activeLocation)
+import Common.Prelude
+
 import qualified LunaStudio.API.Atom.CloseFile      as CloseFile
 import qualified LunaStudio.API.Atom.Copy           as Copy
 import qualified LunaStudio.API.Atom.CreateProject  as CreateProject
@@ -19,77 +17,83 @@ import qualified LunaStudio.API.Atom.Substitute     as Substitute
 import qualified LunaStudio.API.Control.Interpreter as Interpreter
 import qualified LunaStudio.API.Graph.Redo          as Redo
 import qualified LunaStudio.API.Graph.Undo          as Undo
-import           LunaStudio.Data.GraphLocation      (GraphLocation (..))
-import           LunaStudio.Data.Range              (Range)
-import           LunaStudio.Data.TextDiff           (TextDiff)
 
--- Atom requests --
+import Common.Batch.Connector.Connection (Message (Message), sendRequest)
+import Data.UUID.Types                   (UUID)
+import JS.Atom                           (activeLocation)
+import LunaStudio.Data.GraphLocation     (GraphLocation (..))
+import LunaStudio.Data.Range             (Range)
+import LunaStudio.Data.TextDiff          (TextDiff)
 
-closeFile :: FilePath -> UUID -> Maybe UUID -> IO ()
-closeFile path uuid guiID = sendRequest $ Message uuid guiID
+closeFile :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+closeFile path uuid guiID = sendRequest . Message uuid guiID
     $ CloseFile.Request path
 
-createProject :: FilePath -> UUID -> Maybe UUID -> IO ()
-createProject path uuid guiID = sendRequest $ Message uuid guiID
+createProject :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+createProject path uuid guiID = sendRequest . Message uuid guiID
     $ CreateProject.Request path
 
-fileChanged :: FilePath -> UUID -> Maybe UUID -> IO ()
-fileChanged path uuid guiID = sendRequest $ Message uuid guiID
+fileChanged :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+fileChanged path uuid guiID = sendRequest . Message uuid guiID
     $ FileChanged.Request path
 
-getBuffer :: FilePath -> UUID -> Maybe UUID -> IO ()
-getBuffer path uuid guiID = sendRequest $ Message uuid guiID
+getBuffer :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+getBuffer path uuid guiID = sendRequest . Message uuid guiID
     $ GetBuffer.Request path
 
-isSaved :: FilePath -> UUID -> Maybe UUID -> IO ()
-isSaved path uuid guiID = sendRequest $ Message uuid guiID
+isSaved :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+isSaved path uuid guiID = sendRequest . Message uuid guiID
     $ IsSaved.Request path
 
-openFile :: FilePath -> UUID -> Maybe UUID -> IO ()
-openFile path uuid guiID = sendRequest $ Message uuid guiID
+openFile :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+openFile path uuid guiID = sendRequest . Message uuid guiID
     $ OpenFile.Request path
 
-saveFile :: FilePath -> UUID -> Maybe UUID -> IO ()
-saveFile path uuid guiID = sendRequest $ Message uuid guiID
+saveFile :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+saveFile path uuid guiID = sendRequest . Message uuid guiID
     $ SaveFile.Request path
 
-setProject :: FilePath -> UUID -> Maybe UUID -> IO ()
-setProject rootPath uuid guiID = sendRequest $ Message uuid guiID
+setProject :: MonadIO m => FilePath -> UUID -> Maybe UUID -> m ()
+setProject rootPath uuid guiID = sendRequest . Message uuid guiID
     $ SetProject.Request rootPath
 
-moveProject :: FilePath -> FilePath -> UUID -> Maybe UUID -> IO ()
-moveProject oldPath newPath uuid guiID = sendRequest $ Message uuid guiID
+moveProject :: MonadIO m => FilePath -> FilePath -> UUID -> Maybe UUID -> m ()
+moveProject oldPath newPath uuid guiID = sendRequest . Message uuid guiID
     $ MoveProject.Request oldPath newPath
 
-substitute :: GraphLocation -> [TextDiff] -> UUID -> Maybe UUID -> IO ()
+substitute
+    :: MonadIO m => GraphLocation -> [TextDiff] -> UUID -> Maybe UUID -> m ()
 substitute location diffs uuid guiID =
-    sendRequest $ Message uuid guiID $ Substitute.Request location diffs
+    sendRequest . Message uuid guiID $ Substitute.Request location diffs
 
-copy :: FilePath -> [Range] -> UUID -> Maybe UUID -> IO ()
-copy path spans uuid guiID = sendRequest $ Message uuid guiID
+copy :: MonadIO m => FilePath -> [Range] -> UUID -> Maybe UUID -> m ()
+copy path spans uuid guiID = sendRequest . Message uuid guiID
     $ Copy.Request path spans
 
-paste :: GraphLocation -> [Range] -> [Text] -> UUID -> Maybe UUID -> IO ()
-paste location spans content uuid guiID = sendRequest $ Message uuid guiID
+paste :: MonadIO m
+      => GraphLocation -> [Range] -> [Text] -> UUID -> Maybe UUID -> m ()
+paste location spans content uuid guiID = sendRequest . Message uuid guiID
     $ Paste.Request location spans content
 
-undo :: UUID -> Maybe UUID -> IO ()
-undo uuid guiID = sendRequest $ Message uuid guiID $ Undo.Request Undo.UndoRequest
+undo :: MonadIO m => UUID -> Maybe UUID -> m ()
+undo uuid guiID
+    = sendRequest . Message uuid guiID $ Undo.Request Undo.UndoRequest
 
-redo :: UUID -> Maybe UUID -> IO ()
-redo uuid guiID = sendRequest $ Message uuid guiID $ Redo.Request Redo.RedoRequest
+redo :: MonadIO m => UUID -> Maybe UUID -> m ()
+redo uuid guiID
+    = sendRequest . Message uuid guiID $ Redo.Request Redo.RedoRequest
 
-interpreterPause :: UUID -> Maybe UUID -> IO ()
+interpreterPause :: MonadIO m => UUID -> Maybe UUID -> m ()
 interpreterPause uuid guiID = do
     loc <- fromMaybe (GraphLocation def def) <$> activeLocation
-    sendRequest $ Message uuid guiID $ Interpreter.Request loc Interpreter.Pause
+    sendRequest . Message uuid guiID $ Interpreter.Request loc Interpreter.Pause
 
-interpreterStart :: UUID -> Maybe UUID -> IO ()
+interpreterStart :: MonadIO m => UUID -> Maybe UUID -> m ()
 interpreterStart uuid guiID = do
     loc <- fromMaybe (GraphLocation def def) <$> activeLocation
-    sendRequest $ Message uuid guiID $ Interpreter.Request loc Interpreter.Start
+    sendRequest . Message uuid guiID $ Interpreter.Request loc Interpreter.Start
 
-interpreterReload :: UUID -> Maybe UUID -> IO ()
+interpreterReload :: MonadIO m => UUID -> Maybe UUID -> m ()
 interpreterReload uuid guiID = do
     loc <- fromMaybe (GraphLocation def def) <$> activeLocation
-    sendRequest $ Message uuid guiID $ Interpreter.Request loc Interpreter.Reload
+    sendRequest . Message uuid guiID $ Interpreter.Request loc Interpreter.Reload

--- a/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
+++ b/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
@@ -2,48 +2,64 @@ module TextEditor.Handler.Text
     ( handle
     ) where
 
-import           Common.Action.Command             (Command)
-import           Common.Prelude
-import qualified JS.Atom                           as JS
-import qualified LunaStudio.API.Atom.Copy          as Copy
-import qualified LunaStudio.API.Atom.GetBuffer     as GetBuffer
-import qualified LunaStudio.API.Atom.Substitute    as Substitute
-import qualified LunaStudio.API.Response           as Response
-import           LunaStudio.Data.GraphLocation     (GraphLocation (GraphLocation))
-import qualified TextEditor.Action.Batch           as ActBatch
-import           TextEditor.Event.Batch            (BatchEvent (..))
-import           TextEditor.Event.Event            (Event (Atom, Batch, Text))
-import           TextEditor.Event.Internal         (InternalEvent (..))
-import           TextEditor.Event.Text             (TextEvent (..))
-import           TextEditor.Handler.Backend.Common (doNothing, doNothing2, handleResponse)
-import           TextEditor.State.Global           (State)
+import Common.Prelude
+
+import qualified JS.Atom                        as JS
+import qualified LunaStudio.API.Atom.Copy       as Copy
+import qualified LunaStudio.API.Atom.GetBuffer  as GetBuffer
+import qualified LunaStudio.API.Atom.Substitute as Substitute
+import qualified LunaStudio.API.Response        as Response
+import qualified TextEditor.Action.Batch        as ActBatch
+import qualified TextEditor.State.Global        as State
+
+import Common.Action.Command             (Command)
+import LunaStudio.Data.GraphLocation     (GraphLocation (GraphLocation))
+import TextEditor.Event.Batch            (BatchEvent (..))
+import TextEditor.Event.Event            (Event (Atom, Batch, Text))
+import TextEditor.Event.Internal         (InternalEvent (..))
+import TextEditor.Event.Text             (TextEvent (..))
+import TextEditor.Handler.Backend.Common (doNothing, doNothing2, handleResponse)
+import TextEditor.State.Global           (State)
 
 
 handle :: Event -> Maybe (Command State ())
-handle (Text (TextEvent location diffs)) = Just $ ActBatch.substitute location diffs
+handle (Text (TextEvent location diffs))
+    = Just $ ActBatch.substitute location diffs
 handle (Atom (GetBuffer filepath)) = Just $ ActBatch.getBuffer filepath
 handle (Atom (FileChanged filepath)) = Just $ ActBatch.fileChanged filepath
-handle (Atom (Copy filepath selections)) = Just $ ActBatch.copy filepath $ convert selections
-handle (Atom (Paste selections content)) = Just $
-    withJustM_ JS.activeLocation $ \location ->
+handle (Atom (Copy filepath selections))
+    = Just . ActBatch.copy filepath $ convert selections
+handle (Atom (Paste selections content))
+    = Just .  withJustM_ JS.activeLocation $ \location ->
         ActBatch.paste location (convert selections) content
 handle (Atom Undo) = Just ActBatch.undo
 handle (Atom Redo) = Just ActBatch.redo
 
-handle (Batch (SubstituteResponse response)) = Just $ handleResponse response doNothing doNothing2
-handle (Batch (BufferGetResponse  response)) = Just $ handleResponse response success doNothing2 where
-    success result = do
-        let uri  = response ^. Response.request . GetBuffer.filePath
-            code = result ^. GetBuffer.code
-        liftIO $ JS.setBuffer (convert uri) (convert code)
-handle (Batch (CopyResponse  response)) = Just $ handleResponse response success doNothing2 where
-    success result = do
-        let uri  = response ^. Response.request . Copy.filePath
-            code = result ^. Copy.code
-        liftIO $ JS.setClipboard (convert uri) (convert code)
+handle (Batch (SubstituteResponse response))
+    = Just $ handleResponse response success doNothing2 where
+        success result = do
+            let uuid = response ^. Response.requestId
+            shouldHandle <- State.checkResponse uuid
+            when shouldHandle $ do
+                let request = response ^. Response.request
+                    location = request ^. Substitute.location
+                    diffs    = request ^. Substitute.diffs
+                liftIO . JS.insertCode $ TextEvent location diffs
+handle (Batch (BufferGetResponse  response))
+    = Just $ handleResponse response success doNothing2 where
+        success result = do
+            let uri  = response ^. Response.request . GetBuffer.filePath
+                code = result ^. GetBuffer.code
+            liftIO $ JS.setBuffer (convert uri) (convert code)
+handle (Batch (CopyResponse  response))
+    = Just $ handleResponse response success doNothing2 where
+        success result = do
+            let uri  = response ^. Response.request . Copy.filePath
+                code = result ^. Copy.code
+            liftIO $ JS.setClipboard (convert uri) (convert code)
 
 handle (Batch (SubstituteUpdate (Substitute.Update path diffs))) =
-    Just $ liftIO $ JS.insertCode $ TextEvent (GraphLocation path def) diffs
+    Just . liftIO . JS.insertCode $ TextEvent (GraphLocation path def) diffs
 
 
 handle _ = Nothing

--- a/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
+++ b/luna-studio/text-editor/src/TextEditor/Handler/Text.hs
@@ -44,22 +44,22 @@ handle (Batch (SubstituteResponse response))
                 let request = response ^. Response.request
                     location = request ^. Substitute.location
                     diffs    = request ^. Substitute.diffs
-                liftIO . JS.insertCode $ TextEvent location diffs
+                JS.insertCode $ TextEvent location diffs
 handle (Batch (BufferGetResponse  response))
     = Just $ handleResponse response success doNothing2 where
         success result = do
             let uri  = response ^. Response.request . GetBuffer.filePath
                 code = result ^. GetBuffer.code
-            liftIO $ JS.setBuffer (convert uri) (convert code)
+            JS.setBuffer (convert uri) code
 handle (Batch (CopyResponse  response))
     = Just $ handleResponse response success doNothing2 where
         success result = do
             let uri  = response ^. Response.request . Copy.filePath
                 code = result ^. Copy.code
-            liftIO $ JS.setClipboard (convert uri) (convert code)
+            JS.setClipboard (convert uri) code
 
 handle (Batch (SubstituteUpdate (Substitute.Update path diffs))) =
-    Just . liftIO . JS.insertCode $ TextEvent (GraphLocation path def) diffs
+    Just . JS.insertCode $ TextEvent (GraphLocation path def) diffs
 
 
 handle _ = Nothing

--- a/luna-studio/text-editor/src/TextEditor/State/Global.hs
+++ b/luna-studio/text-editor/src/TextEditor/State/Global.hs
@@ -1,26 +1,32 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module TextEditor.State.Global where
 
-import           Common.Action.Command                    (Command)
-import           Common.Prelude
-import           Data.Aeson                               (ToJSON, toJSON)
-import           Data.Map                                 (Map)
-import           Data.Time.Clock                          (UTCTime)
-import           Data.UUID.Types                          (UUID)
-import           Data.Word                                (Word8)
-import           Luna.Benchmark                           (HasRequestTimes, requestTimes)
-import           LunaStudio.API.Graph.CollaborationUpdate (ClientId)
-import           System.Random                            (StdGen)
-import qualified System.Random                            as Random
-import           TextEditor.Event.Event                   (Event)
+import Common.Prelude
+
+import qualified Data.Set      as Set
+import qualified System.Random as Random
+
+import Common.Action.Command                    (Command)
+import Data.Aeson                               (ToJSON, toJSON)
+import Data.Map                                 (Map)
+import Data.Set                                 (Set)
+import Data.Time.Clock                          (UTCTime)
+import Data.UUID.Types                          (UUID)
+import Data.Word                                (Word8)
+import Luna.Benchmark                           (HasRequestTimes, requestTimes)
+import LunaStudio.API.Graph.CollaborationUpdate (ClientId)
+import System.Random                            (StdGen)
+import TextEditor.Event.Event                   (Event)
 
 
-data State = State { _lastEvent            :: Maybe Event
-                   , _eventNum             :: Int
-                   , _pendingRequests      :: Map UUID UTCTime
-                   , _clientId             :: ClientId
-                   , _random               :: StdGen
-                   }
+data State = State
+    { _lastEvent        :: Maybe Event
+    , _eventNum         :: Int
+    , _pendingRequests  :: Map UUID UTCTime
+    , _ignoredResponses :: Set UUID
+    , _clientId         :: ClientId
+    , _random           :: StdGen
+    }
 
 instance ToJSON StdGen where
     toJSON _ = toJSON "(random-generator)"
@@ -28,10 +34,22 @@ instance ToJSON StdGen where
 makeLenses ''State
 
 mkState :: ClientId -> StdGen -> State
-mkState = State def def def
+mkState = State def def def def
 
 nextRandom :: Command State Word8
 nextRandom = uses random Random.random >>= \(val, rnd) -> random .= rnd >> return val
 
 instance HasRequestTimes State where
     requestTimes = pendingRequests
+
+-- === Ignored responses === --
+
+ignoreResponse :: UUID -> Command State ()
+ignoreResponse uuid = ignoredResponses %= Set.insert uuid
+
+checkResponse :: UUID -> Command State Bool
+checkResponse uuid = do
+    responses <- use ignoredResponses
+    let shouldHandle = Set.notMember uuid responses
+    ignoredResponses .= Set.delete uuid responses
+    pure shouldHandle


### PR DESCRIPTION
### Pull Request Description

This fixes handling updates from backend when using the text editor. Fixes the instances of #1323. Also a bunch of random reformattings in the touched files.

### Important Notes

The way we handle this is to handle Substitute updates selectively – when they arise when typing, they are ignored (since the Atom state already knows about tem). When they arise as a result of using undo-redo, they are applied, thus making the whole system behave properly and not apply states when it would disturb the user.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

