### PR TITLE
Search by tags

### DIFF
--- a/libs/luna-studio-common/src/LunaStudio/Data/Searcher/Hint.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Searcher/Hint.hs
@@ -21,6 +21,7 @@ import Data.Text    (Text)
 data Raw = Raw
     { _name          :: Text
     , _documentation :: Text
+    , _tags          :: [Text]
     } deriving (Eq, Generic, Show)
 
 makeLenses ''Raw
@@ -33,4 +34,8 @@ instance ToJSON Raw where
     toEncoding = LensAeson.toEncoding
 
 instance FromJSON Raw where
-    parseJSON = LensAeson.parse
+    parseJSON = Aeson.withObject "Raw" $ \o -> do
+        name <- o Aeson..:  "name"
+        doc  <- o Aeson..:  "documentation"
+        tags <- o Aeson..:? "tags" Aeson..!= mempty
+        pure $ Raw name doc tags

--- a/luna-studio/lib/src/Common/Prelude.hs
+++ b/luna-studio/lib/src/Common/Prelude.hs
@@ -42,7 +42,7 @@ import           Prelude                   hiding (curry, error, print, putStr, 
 import           Prologue                  as X (FromList, IsList, Item, Mempty, NFData, Semigroup, ToList, convert, curry, fmap1, fmap2,
                                                  fmap3, fmap4, fmap5, fromJustM, fromList, lift2, lift3, pprint, putStr, switch, toList,
                                                  toString, uncurry, unlessM, unsafeFromJust, unwrap, whenLeft, whenM, whenM_, whenRight, withJust, wrap,
-                                                 wrapped, ($>), (<<$>>), (.), (.:), (.:.), (.::), (.::.))
+                                                 wrapped, ($>), (<<$>>), (<<*>>), (.), (.:), (.:.), (.::), (.::.))
 import           System.FilePath           as X ((</>))
 
 foreign import javascript safe "console.log($1)" consoleLog :: JSString -> IO ()

--- a/luna-studio/lib/src/Searcher/Data/Class.hs
+++ b/luna-studio/lib/src/Searcher/Data/Class.hs
@@ -4,6 +4,7 @@ import Common.Prelude
 
 class SearcherData a where
     text :: Getter a Text
+    tags :: Getter a [Text]
 
 class SearcherData a => SearcherHint a where
     prefix        :: Getter a Text

--- a/luna-studio/lib/src/Searcher/Data/Match.hs
+++ b/luna-studio/lib/src/Searcher/Data/Match.hs
@@ -26,16 +26,28 @@ letterRange = flip Range 1
 
 -- === Definition === --
 
-newtype Match = Match [Range] deriving (Show, Eq, Generic)
-makeWrapped ''Match
+data MatchSource
+    = None
+    | Expression
+    | Tag
+    deriving (Show, Eq, Generic)
+makePrisms ''MatchSource
+instance NFData MatchSource
+
+data Match = Match
+    { _source :: MatchSource
+    , _range  :: [Range]
+    } deriving (Show, Eq, Generic)
+makeLenses ''Match
 instance NFData Match
 
-instance Default Match where def = Match []
+instance Default Match where
+    def = Match None mempty
 
 -- === Construction === --
 
-fromList :: [Int] -> Match
-fromList matchedPositions = Match $ go Nothing matchedPositions where
+make :: MatchSource -> [Int] -> Match
+make source matchedPositions = Match source $ go Nothing matchedPositions where
     go (Just r) []           = [r]
     go Nothing  []           = []
     go (Just r) (pos : poss) =

--- a/luna-studio/lib/src/Searcher/Data/Result.hs
+++ b/luna-studio/lib/src/Searcher/Data/Result.hs
@@ -2,7 +2,8 @@ module Searcher.Data.Result where
 
 import Common.Prelude
 
-import Searcher.Data.Class (SearcherData (text),
+import Data.Ord            (comparing)
+import Searcher.Data.Class (SearcherData (text, tags),
                             SearcherHint (documentation, prefix))
 import Searcher.Data.Match (Match)
 
@@ -14,7 +15,8 @@ import Searcher.Data.Match (Match)
 -- === Definition === --
 
 data Result a = Result
-    { _hint :: a
+    { _id    :: Int
+    , _hint  :: a
     , _score :: Double
     , _match :: Match
     } deriving (Functor, Show, Eq, Generic)
@@ -22,6 +24,7 @@ makeLenses ''Result
 
 instance SearcherData a => SearcherData (Result a) where
     text = hint . text
+    tags = hint . tags
 
 instance SearcherHint a => SearcherHint (Result a) where
     prefix        = hint . prefix
@@ -31,6 +34,11 @@ instance NFData a => NFData (Result a)
 
 -- === Construction === --
 
-make :: a -> Result a
-make = \a -> Result a 0 def
+make :: Int -> a -> Result a
+make = \id a -> Result id a 0 def
 {-# INLINE make #-}
+
+-- === Utils === --
+
+maxByScore :: Result a -> Result a -> Result a
+maxByScore res1 res2 = if res1 ^. score > res2 ^. score then res1 else res2


### PR DESCRIPTION
### Pull Request Description
This adds searching by function tags to the node searcher.
Since there isn't such a thing as "tags" yet, it works on a mocked structure, adding a bunch of tags for arithmetic operators. This is to be replaced by a proper way of parsing them from the documentation.

### Important Notes
Nothing interesting happens here, very routine changes.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

