### PR TITLE
Score searcher hints based on definition order

### DIFF
--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -49,7 +49,7 @@ packages:
 - {location: ../../tools/batch/plugins/luna-empire}
 - {location: ../../tools/batch/plugins/request-monitor}
 - extra-dep: true
-  location: {commit: 4bdaa65191868185982e3a2889b1404edfd1f138, git: 'https://github.com/luna/luna.git'}
+  location: {commit: b1217b8a8d0f73d4f72fe9b14b18e195f0251b7a, git: 'https://github.com/luna/luna.git'}
   subdirs:
     - core
     - syntax/text/parser

--- a/build-config/backend/stack.yaml
+++ b/build-config/backend/stack.yaml
@@ -49,7 +49,7 @@ packages:
 - {location: ../../tools/batch/plugins/luna-empire}
 - {location: ../../tools/batch/plugins/request-monitor}
 - extra-dep: true
-  location: {commit: 0aa5f8dffb60e3874346f382362e0754ca5d8511, git: 'https://github.com/luna/luna.git'}
+  location: {commit: 4bdaa65191868185982e3a2889b1404edfd1f138, git: 'https://github.com/luna/luna.git'}
   subdirs:
     - core
     - syntax/text/parser

--- a/libs/luna-empire/src/Empire/Commands/Typecheck.hs
+++ b/libs/luna-empire/src/Empire/Commands/Typecheck.hs
@@ -135,7 +135,7 @@ resolveSymbol units tgt = do
             methodRef     <- classRef ^? Class.methods . wrapped . ix method
             pure methodRef
         Target.Unknown                 -> Nothing
-    symbolBody <- symbolRef ^? Def.documented . Def._Body
+    symbolBody <- symbolRef ^? Def.documented . Def._Sourced . Def.body
     pure symbolBody
 
 makeError :: Error.CompileError -> NodeValue

--- a/libs/luna-studio-common/src/LunaStudio/Data/Searcher/Hint.hs
+++ b/libs/luna-studio-common/src/LunaStudio/Data/Searcher/Hint.hs
@@ -22,6 +22,7 @@ data Raw = Raw
     { _name          :: Text
     , _documentation :: Text
     , _tags          :: [Text]
+    , _priority      :: Maybe Int
     } deriving (Eq, Generic, Show)
 
 makeLenses ''Raw
@@ -35,15 +36,16 @@ instance ToJSON Raw where
 
 instance FromJSON Raw where
     parseJSON = Aeson.withObject "Raw" $ \o -> do
-        name <- o Aeson..:  "name"
-        doc  <- o Aeson..:  "documentation"
-        tags <- o Aeson..:? "tags" Aeson..!= mempty
-        pure $ Raw name doc tags
+        name     <- o Aeson..:  "name"
+        doc      <- o Aeson..:  "documentation"
+        tags     <- o Aeson..:? "tags" Aeson..!= mempty
+        priority <- o Aeson..:? "priority"
+        pure $ Raw name doc tags priority
 
 -- === Construction === --
 
 mk :: Text -> Raw
-mk name = Raw name mempty mempty
+mk name = Raw name mempty mempty mempty
 
-mkDocumented :: Text -> Text -> Raw
+mkDocumented :: Text -> Text -> Maybe Int -> Raw
 mkDocumented name doc = Raw name doc mempty

--- a/luna-studio/lib/src/Searcher/Data/Class.hs
+++ b/luna-studio/lib/src/Searcher/Data/Class.hs
@@ -3,8 +3,9 @@ module Searcher.Data.Class where
 import Common.Prelude
 
 class SearcherData a where
-    text :: Getter a Text
-    tags :: Getter a [Text]
+    text     :: Getter a Text
+    tags     :: Getter a [Text]
+    priority :: Getter a (Maybe Int)
 
 class SearcherData a => SearcherHint a where
     prefix        :: Getter a Text

--- a/luna-studio/lib/src/Searcher/Data/Result.hs
+++ b/luna-studio/lib/src/Searcher/Data/Result.hs
@@ -3,7 +3,7 @@ module Searcher.Data.Result where
 import Common.Prelude
 
 import Data.Ord            (comparing)
-import Searcher.Data.Class (SearcherData (text, tags),
+import Searcher.Data.Class (SearcherData (text, tags, priority),
                             SearcherHint (documentation, prefix))
 import Searcher.Data.Match (Match)
 
@@ -23,8 +23,9 @@ data Result a = Result
 makeLenses ''Result
 
 instance SearcherData a => SearcherData (Result a) where
-    text = hint . text
-    tags = hint . tags
+    text     = hint . text
+    tags     = hint . tags
+    priority = hint . priority
 
 instance SearcherHint a => SearcherHint (Result a) where
     prefix        = hint . prefix

--- a/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/Hint/Node.hs
+++ b/luna-studio/node-editor-view/src/NodeEditor/React/Model/Searcher/Hint/Node.hs
@@ -56,14 +56,16 @@ data Node = Node
     , _kind          :: Kind
     , _documentation :: Text
     , _tags          :: [Text]
+    , _priority      :: Maybe Int
     } deriving (Eq, Generic, Show)
 
 makeLenses ''Node
 
 instance NFData Node
 instance SearcherData Node where
-    text = expression
-    tags = tags
+    text     = expression
+    tags     = tags
+    priority = priority
 instance SearcherHint Node where
     prefix        = kind . className . to (fromMaybe mempty)
     documentation = documentation
@@ -71,11 +73,12 @@ instance SearcherHint Node where
 -- === API === --
 
 fromRawHint :: Hint.Raw -> Library.Info -> Kind -> Node
-fromRawHint raw libInfo kind' = let
-    expr = raw ^. Hint.name
-    doc  = raw ^. Hint.documentation
-    tags = raw ^. Hint.tags
-    in Node expr libInfo kind' doc tags
+fromRawHint raw libInfo kind = let
+    expr     = raw ^. Hint.name
+    doc      = raw ^. Hint.documentation
+    tags     = raw ^. Hint.tags
+    priority = raw ^. Hint.priority
+    in Node expr libInfo kind doc tags priority
 {-# INLINE fromRawHint #-}
 
 fromFunction :: Library.Info -> Hint.Raw -> Node


### PR DESCRIPTION
### Pull Request Description
Searcher now takes function/method definition order when displaying hints. The higher the function defined, the more prominently featured it is.

### Important Notes
Straightforward.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

