### PR TITLE
Remove file-icons

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -1,6 +1,5 @@
 column-select 0.2.0
 cursor-history 0.11.1
-file-icons 2.1.11
 hasklig 0.4.0
 highlight-line 0.12.0
 highlight-selected 0.13.1


### PR DESCRIPTION
### Pull Request Description
Fixes #1365. By removing the package altogether. The fixed version also fails to activate, with a different error, I assume it's because of the oooooold Atom version we use.
Difference in behavior is barely noticable (file icons in tree view are a bit less rich). Since we plan to ditch Atom anyway, I'm proposing this as a temporary measure.

### Important Notes
None.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md) if it is Haskell.
- [x] The code has been tested where possible.

