### PR TITLE
Fix backendLdLibraryPath

### DIFF
--- a/runner/src/StudioRunner.hs
+++ b/runner/src/StudioRunner.hs
@@ -130,6 +130,7 @@ getRunnerDir = liftIO $ do
     x <- getExecutablePath
     parent <$> parseAbsFile x
 
+-- | Path to application package root
 absAppDir :: MonadIO m => m (Path Abs Dir)
 absAppDir = do
     runnerDir <- getRunnerDir
@@ -143,6 +144,7 @@ absAppDir = do
                  else parent . parent . parent -- drop bin/public/luna-studio/
     pure $ stepUp runnerDir
 
+-- | Path to application directory inside user home directory
 absHomeDir ::  MonadRun m => m (Path Abs Dir)
 absHomeDir = do
     runnerCfg <- get @RunnerConfig
@@ -209,8 +211,8 @@ userStudioAtomHome = do
     baseDir   <- buildDirectoryPath absHomeDir [configHomeFolder, appName] >>= \x -> fmap (x </>) (parseRelDir =<< version)
     pure $ baseDir </> (runnerCfg ^. studioHome)
 backendLdLibraryPath = do
-    ldLibPath <- PIO.getCurrentDir
-    pure $ ldLibPath </> $(mkRelDir "lib/zeromq")
+    appDir <- absAppDir
+    pure $ appDir </> $(mkRelDir "lib/zeromq")
 
 atomAppPath, killSupervisorBinPath, supervisordBinPath :: MonadRun m => m (Path Abs File)
 supervisorctlBinPath, versionFilePath, userInfoPath    :: MonadRun m => m (Path Abs File)


### PR DESCRIPTION
### Pull Request Description
Currently `backendLdLibraryPath` depends on CWD. It should instead reuse `absAppDir`.

If you build luna studio and start it from the `dist` directory then everything works fine. If however you start it from any other directory:
- some backend services fail to start as they cannot find zeromq libs: `exited: luna-double-representation (exit status 127; not expected)`
- atom starts but projects do not fully load because the backend isn't properly initialized (super confusing if the user doesn't notice errors in the console)

This PR fixes those issues.

### Important Notes
Nothing to report.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Haskell Style Guide](https://github.com/luna/luna/blob/master/doc/haskell-style-guide.md) and/or the [TypeScript Style Guide](https://github.com/luna/luna-studio/blob/master/doc/typescript-style-guide.md).
- [x] The code has been tested where possible.

