### PR TITLE
supervisord config shall not rely on PWD variable

### DIFF
--- a/runner/src/StudioRunner.hs
+++ b/runner/src/StudioRunner.hs
@@ -293,11 +293,11 @@ supervisorctl args = do
 supervisord :: MonadRun m => Path Rel File -> m ()
 supervisord configFile = do
     supervisorBinPath <- toFilePath <$> supervisordBinPath
-    supervisorDir     <- toFilePath <$> backendDir
+    supervisorDir     <- backendDir
     ldLibPath         <- liftIO $ lookupEnv "LD_LIBRARY_PATH"
     setEnv "OLD_LIBPATH" $ fromMaybe "\"\"" ldLibPath
-    runProcess_ $ setWorkingDir supervisorDir
-                $ proc supervisorBinPath ["-n", "-c", toFilePath configFile]
+    let configFileAbs = supervisorDir </> configFile
+    runProcess_ $ proc supervisorBinPath ["-n", "-c", toFilePath configFileAbs]
 
 stopSupervisor :: MonadRun m => m ()
 stopSupervisor = void $ supervisorctl ["shutdown"]

--- a/supervisor/supervisord-package.conf
+++ b/supervisor/supervisord-package.conf
@@ -42,19 +42,19 @@ events=PROCESS_STATE_EXITED
 [program:luna-ws-connector]
 environment=LD_LIBRARY_PATH=%(ENV_LUNA_STUDIO_BACKEND_LD_LIBRARY_PATH)s
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-ws-connector -v5
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 
 [program:luna-broker]
 environment=LD_LIBRARY_PATH=%(ENV_LUNA_STUDIO_BACKEND_LD_LIBRARY_PATH)s
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-broker -v5
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 
 [program:luna-double-representation]
 environment=LD_LIBRARY_PATH=%(ENV_LUNA_STUDIO_BACKEND_LD_LIBRARY_PATH)s
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-double-representation -v5
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/luna-double-representation.log
 ; stdout_logfile_maxbytes=1MB
@@ -69,7 +69,7 @@ redirect_stderr=true
 [program:luna-undo-redo]
 environment=LD_LIBRARY_PATH=%(ENV_LUNA_STUDIO_BACKEND_LD_LIBRARY_PATH)s
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-undo-redo -v5
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/luna-undo-redo.log
 ; stdout_logfile_maxbytes=1MB

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -25,19 +25,19 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 [program:luna-ws-connector]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-ws-connector -v5
 environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 
 [program:luna-broker]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-broker -v5
 environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 
 [program:luna-double-representation]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-double-representation -v5
 environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/luna-double-representation.log
 ; stdout_logfile_maxbytes=1MB
@@ -52,7 +52,7 @@ redirect_stderr=true
 [program:luna-undo-redo]
 command=%(ENV_LUNA_STUDIO_BACKEND_PATH)s/luna-undo-redo -v5
 environment=LD_LIBRARY_PATH=%(ENV_OLD_LIBPATH)s
-directory=%(ENV_PWD)s/
+directory=%(here)s/
 redirect_stderr=true
 ; stdout_logfile=%(ENV_LUNA_STUDIO_LOG_PATH)s/luna-undo-redo.log
 ; stdout_logfile_maxbytes=1MB


### PR DESCRIPTION
### Pull Request Description
This PR fixes #1385 — a regression introduced when moving away from shelly. As I recommended a shell call was replaced with direct process spawn. However, the spawned `supervisord` not only relies on its working directory — it also needed a PWD environment variable, as it was used in our configuration files.

This PR fixes this:
1) by using relative paths in configuration files — so they work no matter what the PWD value is (or when it is not present at all)
2) the runner shall pass absolute path to the configuration file to the supervisord — so it can be spawned without adjusting working directory

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs. 
-->

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Haskell Style Guide](https://github.com/luna/luna/blob/master/doc/haskell-style-guide.md)
  and/or the [TypeScript Style Guide](https://github.com/luna/luna-studio/blob/master/doc/typescript-style-guide.md).
- [x] The code has been tested where possible.

