### PR TITLE
Fix build on Windows by qualifing the imports with package name

### DIFF
--- a/runner/src/StudioRunner.hs
+++ b/runner/src/StudioRunner.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 
@@ -12,20 +13,20 @@ module Main where
 
 import Prologue hiding (switch)
 
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.List            as List
-import qualified Data.Set             as Set
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as T
-import qualified Path.IO              as PIO
-import qualified System.Environment   as Environment
+import qualified Data.ByteString.Lazy  as BL
+import qualified Data.List             as List
+import qualified "containers" Data.Set as Set
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as T
+import qualified Path.IO               as PIO
+import qualified System.Environment    as Environment
 
 import Control.Exception.Safe   (bracket_, catchAny)
 import Control.Monad.IO.Class   (MonadIO(..))
 import Control.Monad.State.Lazy (MonadState, evalStateT, get)
 import Data.Maybe               (fromMaybe, maybeToList)
 import Data.Semigroup           ((<>))
-import Data.Set                 (Set)
+import "containers" Data.Set    (Set)
 import Options.Applicative      ( Parser, ParserInfo, ParserPrefs
                                 , execParserPure, handleParseResult, helper, idm
                                 , info, long, optional, prefs, short, strOption


### PR DESCRIPTION
### Pull Request Description
Currently our packaging scripts fail to build runner on Windows:
```
[1 of 2] Compiling System.Host      ( src\System\Host.hs, src\System\Host.o )
[2 of 2] Compiling Main             ( src\StudioRunner.hs, src\StudioRunner.o )

src\StudioRunner.hs:17:1: error:
    Ambiguous interface for ‘Data.Set’:
      it was found in multiple packages:
      container-0.2.9 containers-0.5.7.1

src\StudioRunner.hs:28:1: error:
    Ambiguous interface for ‘Data.Set’:
      it was found in multiple packages:
      container-0.2.9 containers-0.5.7.1
```

The reason is that on Windows we call GHC directly to compile luna-studio.exe, rather than using stack. This is caused by the need to supply it with a custom pre-made resource binary blob, that adds icon to the generated executable (see #647). Apparently having a custom icon is not something that Haskell tooling supports.

This is obviously asking for trouble and this PR only alleviates the immediate issue… but it doesn't seem worthwhile to spend much time on figuring how this should be properly fixed (if possible at all), since the code is deprecated anyway.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs. 
-->

### Checklist
- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Haskell Style Guide](https://github.com/luna/luna/blob/master/doc/haskell-style-guide.md)
  and/or the [TypeScript Style Guide](https://github.com/luna/luna-studio/blob/master/doc/typescript-style-guide.md).
- [ ] The code has been tested where possible.
